### PR TITLE
Fix accessing null object when link does not exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -395,7 +395,7 @@ export default class AtlasTracking {
 
             if (linkElement) {
                 elm = linkElement.element;
-                ext = elm.pathname.match(/.+\/.+?\.([a-z]+([?#;].*)?$)/);
+                ext = (elm.pathname || '').match(/.+\/.+?\.([a-z]+([?#;].*)?$)/);
 
                 // Outbound
                 if (obj.trackLink && obj.trackLink.enable && elm.hostname && window.parent.location.hostname !== elm.hostname && obj.trackLink.internalDomains.indexOf(elm.hostname) < 0) {


### PR DESCRIPTION
`href`が設定されていない場合(広告など、リンククリック時の動作がjsで制御されている場合)にエラーが起きていたため修正