### PR TITLE
Fix "matches is not a function" error on IE

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -85,8 +85,6 @@ export default class Utils {
     }
 
     qsM(s, t, d = null) {
-        if (!Element.prototype.matches)
-            Element.prototype.matches = Element.prototype.msMatchesSelector;
         let e = null; // Trackable Element
         let c = 'button';
         let p = []; // Path
@@ -94,8 +92,9 @@ export default class Utils {
             t = t.parentNode;
         }
         while (t && t !== window.parent.document) {
+            let matches = (t.matches || t.msMatchesSelector || function () {return false;}).bind(t);
             if(!d){
-                if(t.matches(s)){
+                if(matches(s)){
                     return {
                         'element': t
                     };
@@ -104,7 +103,7 @@ export default class Utils {
                 if(t.hasAttribute(d)){
                     p.unshift(t.getAttribute(d));
                 }
-                if (!e && t.matches(s)) {
+                if (!e && matches(s)) {
                     if(t.tagName.toLowerCase() === 'a'){
                         c = 'link';
                     }


### PR DESCRIPTION
This PR fixes the issue that `matches is not a function` on IE.
Current implementation already care about IE, but this does not work for `SVGElement`.
So, this PR changes to support all elements which supports `matches` or `msMatchesSelector `.