### PR TITLE
Stop setting cookie in script.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,9 +145,6 @@ export default class AtlasTracking {
         debug = obj.debug !== void 0 ? obj.debug : {};
         options = obj.options !== void 0 ? obj.options : {};
         utils.initSystem(system);
-        if (options && options.exchangeAtlasId && options.exchangeAtlasId.catch) {
-            utils.setAtlasIdFromParam(options.exchangeAtlasId.catchParamKey, options.exchangeAtlasId.catchTargetDomains);
-        }
         if (utils.getC('atlasOutputLog') === 'true' || (debug && debug.outputLog)) {
             debug.outputLog = true;
             console.log('ATJ configured');
@@ -211,11 +208,11 @@ export default class AtlasTracking {
      * @param  {string} s whether optout is enabled or not. ('enable'|'disable')
      */
     optout(s) {
-        let c = utils.getC('atlasOptout');
+        let c = utils.getLS('atlasOptout');
         if (s === 'enable') {
-            window.parent.document.cookie = 'atlasOptout=true;path=/;max-age=4133948399';
+            utils.setLS('atlasOptout', true);
         } else if (s === 'disable') {
-            window.parent.document.cookie = 'atlasOptout=';
+            utils.delLS('atlasOptout');
         } else {
             if (c === 'true') {
                 console.log('enabled');

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,8 +13,6 @@ let atlasEndpoint = null;
 let atlasApiKey = null;
 let atlasBeaconTimeout = null;
 let atlasCookieName = null;
-let atlasCookieMaxAge = null;
-let atlasCookieDomain = null;
 let atlasId = '0';
 let handlerEvents = {};
 let handlerKey = 0;
@@ -30,57 +28,16 @@ export default class Utils {
 
     initSystem(system) {
         const cookies = Cookie.parse(window.parent.document.cookie);
-        let hostname = window.parent.location.hostname;
-        let parsedHostname = hostname.split('.').reverse();
 
         atlasEndpoint = system.endpoint ? system.endpoint : DEFAULT_ENDPOINT;
         atlasApiKey = system.apiKey ? system.apiKey : SDK_API_KEY;
         atlasBeaconTimeout = system.beaconTimeout ? system.beaconTimeout : 2000;
         atlasCookieName = system.cookieName ? system.cookieName : 'atlasId';
-        atlasCookieMaxAge = system.cookieMaxAge ? system.cookieMaxAge : (2 * 365 * 24 * 60 * 60);
-
-        if (system.cookieDomain) {
-            atlasCookieDomain = system.cookieDomain;
-        } else {
-            if (parsedHostname.length <= 2) {
-                atlasCookieDomain = hostname;
-            } else {
-                if (parsedHostname[1].length > 2) {
-                    atlasCookieDomain = parsedHostname[1] + '.' + parsedHostname[0];
-                } else if (parsedHostname[0].length === 2 && parsedHostname[1].length === 2) {
-                    atlasCookieDomain = parsedHostname[2] + '.' + parsedHostname[1] + '.' + parsedHostname[0];
-                } else {
-                    atlasCookieDomain = hostname;
-                }
-            }
-        }
 
         atlasId = cookies[atlasCookieName];
+
         if (!atlasId || atlasId === '0' || atlasId === 0 || atlasId === '1' || atlasId === 1 || atlasId.length < 5) {
             atlasId = (UUID() + UUID()).replace(/-/g, '');
-            window.parent.document.cookie = Cookie.serialize(atlasCookieName, atlasId, {
-                maxAge: atlasCookieMaxAge,
-                domain: atlasCookieDomain,
-                path: '/'
-            });
-        }
-    }
-
-    setAtlasIdFromParam(k, d) {
-        if (!atlasId && window.parent.document.referrer) {
-            let r = window.parent.document.createElement('a');
-            r.href = window.parent.document.referrer;
-            if (d.indexOf(r.hostname) >= 0) {
-                let p = this.getQ(k);
-                if (p) {
-                    atlasId = p;
-                    window.parent.document.cookie = Cookie.serialize(atlasCookieName, atlasId, {
-                        maxAge: atlasCookieMaxAge,
-                        domain: atlasCookieDomain,
-                        path: '/'
-                    });
-                }
-            }
         }
     }
 
@@ -157,6 +114,20 @@ export default class Utils {
             r = '';
         }
         return r;
+    }
+
+    setLS(k, v) {
+        try {
+            window.parent.localStorage.setItem(k, v)
+        } catch (e) {
+        }
+    }
+
+    delLS(k) {
+        try {
+            window.parent.localStorage.removeItem(k)
+        } catch (e) {
+        }
     }
 
     getP() {
@@ -456,7 +427,7 @@ export default class Utils {
         const sync = (dg && dg.syncMode) ? '&sync=true' : '';
         const m = ug ? 'GET' : 'POST'; //method
         const a = (!(ac === 'unload' && ca === 'page')); //async
-        const o = (this.getC('atlasOptout') === 'true') ? true : false;
+        const o = (this.getLS('atlasOptout') === 'true') ? true : false;
         let f = 1; //fpcStatus
         if (this.getC(atlasCookieName) !== atlasId) {
             f = 0;

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,11 +34,12 @@ export default class Utils {
         atlasBeaconTimeout = system.beaconTimeout ? system.beaconTimeout : 2000;
         atlasCookieName = system.cookieName ? system.cookieName : 'atlasId';
 
-        atlasId = cookies[atlasCookieName];
+        atlasId = cookies[atlasCookieName] || getLS('atlasId');
 
         if (!atlasId || atlasId === '0' || atlasId === 0 || atlasId === '1' || atlasId === 1 || atlasId.length < 5) {
             atlasId = (UUID() + UUID()).replace(/-/g, '');
         }
+        setLS('atlasId', atlasId)
     }
 
     qsM(s, t, d = null) {


### PR DESCRIPTION
This PR removes cookie setting in script. `Set-Cookie` should be used to set cookie.
And to mitigate the effect of ITP2.1, it also introduces the backup method of device id.