### PR TITLE
Add disable tracking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -373,6 +373,8 @@ export default class AtlasTracking {
         if (options.trackPerformance && options.trackPerformance.enable) {
             window.parent.removeEventListener('DOMContentLoaded', atlasDOMContentLoadedHandler);
         }
+
+        options = {}
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ let dataSrc = {};
 let defaults = {};
 let supplement = {};
 let performanceInfo = {};
+let atlasDOMContentLoadedHandler = null;
 let eventHandlerKeys = {
     unload: null,
     scroll: null,
@@ -259,11 +260,12 @@ export default class AtlasTracking {
             this.trackForm(options.trackForm.target);
         }
         if (options.trackPerformance && options.trackPerformance.enable) {
-            window.parent.addEventListener('DOMContentLoaded', function () {
+            atlasDOMContentLoadedHandler = function () {
                 performanceInfo = utils.getP();
                 context.navigation_timing = performanceInfo.performanceResult || {};
                 context.navigation_type = performanceInfo.navigationType || {};
-            }, false);
+            };
+            window.parent.addEventListener('DOMContentLoaded', atlasDOMContentLoadedHandler, false);
         }
     }
 
@@ -369,7 +371,7 @@ export default class AtlasTracking {
             }
         }
         if (options.trackPerformance && options.trackPerformance.enable) {
-            window.parent.removeEventListener('DOMContentLoaded');
+            window.parent.removeEventListener('DOMContentLoaded', atlasDOMContentLoadedHandler);
         }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -332,6 +332,48 @@ export default class AtlasTracking {
     }
 
     /**
+     * remove tracking options and handlers
+     */
+    disableTracking() {
+        if (debug && debug.outputLog) {
+            console.log('ATJ removed EventListeners and tracking options');
+        }
+        if ((options.exchangeAtlasId && options.exchangeAtlasId.pass) || (options.trackClick && options.trackClick.enable) || (options.trackLink && options.trackLink.enable) || (options.trackDownload && options.trackDownload.enable)) {
+            eventHandler.remove(eventHandlerKeys['click']);
+        }
+        if (options.trackUnload && options.trackUnload.enable) {
+            eventHandler.remove(eventHandlerKeys['unload']);   
+        }
+        if (options.trackScroll && options.trackScroll.enable) {
+            eventHandler.remove(eventHandlerKeys['scroll']);
+        }
+        if (options.trackInfinityScroll && options.trackInfinityScroll.enable) {
+            eventHandler.remove(eventHandlerKeys['infinityScroll']);
+        }
+        if (options.trackRead && options.trackRead.enable) {
+            eventHandler.remove(eventHandlerKeys['read']);
+        }
+        if (options.trackViewability && options.trackViewability.enable) {
+            eventHandler.remove(eventHandlerKeys['viewability']);
+        }
+        if (options.trackMedia && options.trackMedia.enable) {
+            const targetEvents = ['play', 'pause', 'end'];
+            for (const event of targetEvents) {
+                eventHandler.remove(eventHandlerKeys['media'][event]);
+            }
+        }
+        if (options.trackForm && options.trackForm.enable && options.trackForm.target !== null) {
+            const targetEvents = ['focus', 'change'];
+            for (const event of targetEvents) {
+                eventHandler.remove(eventHandlerKeys['form'][event]);
+            }
+        }
+        if (options.trackPerformance && options.trackPerformance.enable) {
+            window.parent.removeEventListener('DOMContentLoaded');
+        }
+    }
+
+    /**
      * track page view.
      */
     trackPage() {


### PR DESCRIPTION
Add `AtlasTracking.disableTracking` method. When this called, all of tracking handlers and options are deleted. 
After that, user must call `AtlasTracking.initPage` to initialize tracking operations.