### PR TITLE
Add track navigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,11 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
+
       - run: yarn test
 
       - persist_to_workspace:
-          root: ~/workspace 
+          root: ~/workspace
           paths:
               - ./*
 

--- a/dist/c2p.js
+++ b/dist/c2p.js
@@ -47,6 +47,9 @@
                     'fileExtensions': ['pdf', 'zip', 'laz', 'tar', 'gz', 'tgz', 'docx', 'xlsx', 'pptx', 'doc', 'xls', 'ppt'],
                     'nameAttribute': 'data-atlas-link-name',
                 },
+                'trackNavigation': {
+                    'enable': true,
+                },
                 'trackPerformance': {
                     'enable': true,
                 },

--- a/docs/CONFIGURATION-JP.md
+++ b/docs/CONFIGURATION-JP.md
@@ -92,7 +92,8 @@
 |:----:|:----:|:----:|:----:|
 |trackClick.enable|Boolean|この機能を使うか否か|`true`|
 |trackClick.targetAttribute|String|ATJはユーザーがこのデータ属性を持つ要素をクリックしたときにデータを収集する|`data-atlas-trackable`|
-                    
+
+
 #### trackLink (オプション以下)
 
 |変数|型|目的|例|
@@ -107,7 +108,8 @@
 |:----:|:----:|:----:|:----:|
 |trackDownload.enable|Boolean|この機能を使うか否か|`true`|
 |trackDownload.fileExtensions|Array|ダウンロード計測の対象とするファイル拡張子の配列|`['pdf','zip','tar','gz']`|
-|trackDownload.nameAttribute|String|ここで指定したデータ属性を追加して、ダウンロードリンクに任意の名前を設定できる|`data-atlas-link-name`|                    
+|trackDownload.nameAttribute|String|ここで指定したデータ属性を追加して、ダウンロードリンクに任意の名前を設定できる|`data-atlas-link-name`|
+
 
 #### trackNavigation (オプション以下)
 
@@ -221,7 +223,8 @@
 - `user` はユーザーIDや環境などユーザー側の情報を格納するためのもの。
 - Atlas エンドポイントはセッション管理を内蔵しているので `site_session` はセッション管理に不要である。
 - `external_ids` は `initPage()` 以降に `setCustomId()` と `delCustomId()` で管理される。
-                		
+
+
 #### context
 
 |変数|型|目的|例|

--- a/docs/CONFIGURATION-JP.md
+++ b/docs/CONFIGURATION-JP.md
@@ -18,6 +18,7 @@
         'trackClick': {...},
         'trackLink': {...},
         'trackDownload': {...},
+        'trackNavigation': {...},
         'trackPerformance': {...},
         'trackScroll': {...},
         'trackInfinityScroll': {...},
@@ -107,6 +108,13 @@
 |trackDownload.enable|Boolean|この機能を使うか否か|`true`|
 |trackDownload.fileExtensions|Array|ダウンロード計測の対象とするファイル拡張子の配列|`['pdf','zip','tar','gz']`|
 |trackDownload.nameAttribute|String|ここで指定したデータ属性を追加して、ダウンロードリンクに任意の名前を設定できる|`data-atlas-link-name`|                    
+
+#### trackNavigation (オプション以下)
+
+|変数|型|目的|例|
+|:----:|:----:|:----:|:----:|
+|trackNavigation.enable|Boolean|この機能を使うか否か|`true`|
+
 
 #### trackPerformance (オプション以下)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -18,6 +18,7 @@ Most variables except `system` can be omitted but strongly recommend to specify 
         'trackClick': {...},
         'trackLink': {...},
         'trackDownload': {...},
+        'trackNavigation': {...},
         'trackPerformance': {...},
         'trackScroll': {...},
         'trackInfinityScroll': {...},
@@ -107,6 +108,12 @@ Most variables except `system` can be omitted but strongly recommend to specify 
 |trackDownload.enable|Boolean|Use this feature or not|`true`|
 |trackDownload.fileExtensions|Array|Array of file extensions you want to track downloads|`['pdf','zip','tar','gz']`|
 |trackDownload.nameAttribute|String|You can set an alternative name for the file by adding data attribution and specify the attribution name here|`data-atlas-link-name`|                    
+#### trackNavigation (under options)
+
+|Variable|Type|Purpose|Example|
+|:----:|:----:|:----:|:----:|
+|trackNavigation.enable|Boolean|Use this feature or not|`true`|
+
 
 #### trackPerformance (under options)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -92,7 +92,7 @@ Most variables except `system` can be omitted but strongly recommend to specify 
 |:----:|:----:|:----:|:----:|
 |trackClick.enable|Boolean|Use this feature or not|`true`|
 |trackClick.targetAttribute|String|ATJ collects data when user clicked elements which has this data attribution |`data-atlas-trackable`|
-                    
+
 #### trackLink (under options)
 
 |Variable|Type|Purpose|Example|
@@ -107,7 +107,9 @@ Most variables except `system` can be omitted but strongly recommend to specify 
 |:----:|:----:|:----:|:----:|
 |trackDownload.enable|Boolean|Use this feature or not|`true`|
 |trackDownload.fileExtensions|Array|Array of file extensions you want to track downloads|`['pdf','zip','tar','gz']`|
-|trackDownload.nameAttribute|String|You can set an alternative name for the file by adding data attribution and specify the attribution name here|`data-atlas-link-name`|                    
+|trackDownload.nameAttribute|String|You can set an alternative name for the file by adding data attribution and specify the attribution name here|`data-atlas-link-name`|
+
+
 #### trackNavigation (under options)
 
 |Variable|Type|Purpose|Example|
@@ -220,7 +222,8 @@ Most variables can be omitted but it will be helpful for you if you set concrete
 - `user` is to store user side information such as user ID and environment.
 - Atlas Endpoint has built-in session management so `site_session` is not necessary to handle sessions.
 - `external_ids` can be managed by `setCustomId()` and `delCustomId()` after `initPage()`
-                		
+
+
 #### context
 
 |Variable|Type|Purpose|Example|

--- a/src/index.js
+++ b/src/index.js
@@ -346,7 +346,7 @@ export default class AtlasTracking {
             eventHandler.remove(eventHandlerKeys['click']);
         }
         if (options.trackUnload && options.trackUnload.enable) {
-            eventHandler.remove(eventHandlerKeys['unload']);   
+            eventHandler.remove(eventHandlerKeys['unload']);
         }
         if (options.trackScroll && options.trackScroll.enable) {
             eventHandler.remove(eventHandlerKeys['scroll']);

--- a/src/index.js
+++ b/src/index.js
@@ -319,7 +319,9 @@ export default class AtlasTracking {
                 'visibility': window.parent.document.visibilityState || 'unknown'
             };
         }
-
+        if (options.trackNavigation && options.trackNavigation.enable) {
+            context.navigation = utils.getNav() || {};
+        }
         if (options.trackPerformance && options.trackPerformance.enable) {
             performanceInfo = utils.getP();
             context.navigation_timing = performanceInfo.performanceResult || {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -130,6 +130,30 @@ export default class Utils {
         }
     }
 
+    getNav() {
+        let nav = {
+            history_length: window.parent.history.length
+        };
+        if ('performance' in window.parent) {
+            let p = window.parent.performance;
+            if ('getEntriesByType' in p) {
+                let navs = p.getEntriesByType("navigation");
+                if(navs.length >= 1) {
+                    nav.type = navs[0].type;
+                    nav.redirectCount = navs[0].redirectCount;
+                    nav.domContentLoaded = navs[0].domContentLoadedEventStart;
+                }
+            }
+            if ('getEntriesByName' in p) {
+                let paints = p.getEntriesByName("first-paint");
+                if(paints.length >= 1) {
+                    nav.first_paint = paints[0].startTime;
+                }
+            }
+        }
+        return nav;
+    }
+
     getP() {
         let p = {}; // Performance Timing
         let t = {}; // Navigation Type

--- a/test/integration/pages/src/default.js
+++ b/test/integration/pages/src/default.js
@@ -44,6 +44,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 'fileExtensions': ['pdf', 'zip', 'laz', 'tar', 'gz', 'tgz', 'docx', 'xlsx', 'pptx', 'doc', 'xls', 'ppt'],
                 'nameAttribute': 'data-atlas-link-name',
             },
+            'trackNavigation': {
+                'enable': true,
+            },
             'trackPerformance': {
                 'enable': true,
             },

--- a/test/integration/pages/src/track_media.js
+++ b/test/integration/pages/src/track_media.js
@@ -39,6 +39,9 @@ document.addEventListener('DOMContentLoaded', function () {
             'trackDownload': {
                 'enable': false,
             },
+            'trackNavigation': {
+                'enable': true,
+            },
             'trackPerformance': {
                 'enable': false,
             },

--- a/test/integration/pages/src/track_read.js
+++ b/test/integration/pages/src/track_read.js
@@ -43,6 +43,9 @@ document.addEventListener("DOMContentLoaded", function () {
                 'fileExtensions': ['pdf', 'zip', 'laz', 'tar', 'gz', 'tgz', 'docx', 'xlsx', 'pptx', 'doc', 'xls', 'ppt'],
                 'nameAttribute': 'data-atlas-link-name',
             },
+            'trackNavigation': {
+                'enable': true,
+            },
             'trackPerformance': {
                 'enable': true,
             },

--- a/test/integration/pages/src/track_viewability.js
+++ b/test/integration/pages/src/track_viewability.js
@@ -43,6 +43,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 'fileExtensions': ['pdf', 'zip', 'laz', 'tar', 'gz', 'tgz', 'docx', 'xlsx', 'pptx', 'doc', 'xls', 'ppt'],
                 'nameAttribute': 'data-atlas-link-name',
             },
+            'trackNavigation': {
+                'enable': true,
+            },
             'trackPerformance': {
                 'enable': true,
             },

--- a/test/test.html
+++ b/test/test.html
@@ -12,7 +12,7 @@
         <script>
             expect = chai.expect;
         </script>
-        
+
         <!-- tests -->
         <script src="build/test.js"></script>
 


### PR DESCRIPTION
This request will add the trackNavigation option.

```js
context.navigation: {
  type: "reload"  // "navigate", "reload", "back_forward", "prerender"
  redirectCount: 0,
  domContentLoaded: 1023.12345,
  first_paint: 1343.12345,
  history_length: 3
}
```

This feature is partially overlapped with the Performance API.

trackNavigation extracts the items that are important for analysis,
and we are planning to modify the performance api as well.