### PR TITLE
Added auto click tracking

### DIFF
--- a/docs/CONFIGURATION-JP.md
+++ b/docs/CONFIGURATION-JP.md
@@ -93,6 +93,8 @@
 |trackClick.enable|Boolean|この機能を使うか否か|`true`|
 |trackClick.targetAttribute|String|ATJはユーザーがこのデータ属性を持つ要素をクリックしたときにデータを収集する|`data-atlas-trackable`|
 
+- `enable` が `true` であり、 `targetAttribute` に何らかの値が指定されている場合、 `targetAttribute` に指定されたdata属性を持つ要素のみが計測対象となる
+- `enable` が `true` であり、 `targetAttribute` が未指定または `false` の場合、全てのクリッカブル要素が計測対象となる
 
 #### trackLink (オプション以下)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -93,6 +93,9 @@ Most variables except `system` can be omitted but strongly recommend to specify 
 |trackClick.enable|Boolean|Use this feature or not|`true`|
 |trackClick.targetAttribute|String|ATJ collects data when user clicked elements which has this data attribution |`data-atlas-trackable`|
 
+- If `enable` is `true` and `targetAttribute` has a value, elements with data-attribute specified as `targetAttribute` is tracked.
+- If `enable` is `true` but `targetAttribute` is not specified or has `false`, all clickable elements are tracked.
+
 #### trackLink (under options)
 
 |Variable|Type|Purpose|Example|

--- a/src/index.js
+++ b/src/index.js
@@ -376,7 +376,7 @@ export default class AtlasTracking {
             window.parent.removeEventListener('DOMContentLoaded', atlasDOMContentLoadedHandler);
         }
 
-        options = {}
+        options = {};
     }
 
     /**
@@ -419,7 +419,7 @@ export default class AtlasTracking {
     delegateClickEvents(obj) {
         eventHandler.remove(eventHandlerKeys['click']);
         eventHandlerKeys['click'] = eventHandler.add(window.parent.document.body, 'click', function (ev) {
-            const targetAttribute = obj.trackClick && obj.trackClick.targetAttribute ? obj.trackClick.targetAttribute : 'data-trackable';
+            const targetAttribute = obj.trackClick && obj.trackClick.targetAttribute ? obj.trackClick.targetAttribute : false;
             const linkElement = utils.qsM('a', ev.target);
             const trackableElement = utils.qsM('a, button, input, [role="button"]', ev.target, targetAttribute);
             let elm = null;
@@ -463,14 +463,17 @@ export default class AtlasTracking {
                 }
             }
 
-            if (trackableElement) {
+            if (trackableElement && obj.trackClick.enable) {
                 elm = trackableElement.element;
                 utils.transmit('click', trackableElement.category, mandatories, user, context, {
                     'action': {
                         'name': elm.getAttribute(targetAttribute),
                         'location': trackableElement.path,
                         'destination': elm.href || undefined,
+                        'tag': elm.tagName.toLowerCase(),
                         'id': elm.id || undefined,
+                        'class': elm.className || undefined,
+                        'text': (elm.innerText || elm.value || undefined).substr(0,63),
                         'target': elm.target || undefined,
                         'dataset': elm.dataset || undefined
                     }

--- a/src/index.js
+++ b/src/index.js
@@ -473,7 +473,7 @@ export default class AtlasTracking {
                         'tag': elm.tagName.toLowerCase(),
                         'id': elm.id || undefined,
                         'class': elm.className || undefined,
-                        'text': (elm.innerText || elm.value || undefined).substr(0,63),
+                        'text': (elm.innerText || elm.value || '').substr(0,63) || undefined,
                         'target': elm.target || undefined,
                         'dataset': elm.dataset || undefined
                     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,7 @@ export default class Utils {
         }));
     }
 
-    qsM(s, t, d = null) {
+    qsM(s, t, d = false) {
         let e = null; // Trackable Element
         let c = 'button';
         let p = []; // Path
@@ -52,26 +52,37 @@ export default class Utils {
             t = t.parentNode;
         }
         while (t && t !== window.parent.document) {
-            let matches = (t.matches || t.msMatchesSelector || function () {
-                return false;
-            }).bind(t);
-            if (!d) {
-                if (matches(s)) {
-                    return {
-                        'element': t
-                    };
+            let matches = (
+                t.matches ||
+                t.msMatchesSelector ||
+                function () {
+                    return false;
                 }
-            } else {
+            ).bind(t);
+
+            if (d) {
                 if (t.hasAttribute(d)) {
                     p.unshift(t.getAttribute(d));
                 }
-                if (!e && matches(s)) {
-                    if (t.tagName.toLowerCase() === 'a') {
-                        c = 'link';
+            } else {
+                let elm = t.tagName.toLowerCase();
+                if (elm !== 'html' && elm !== 'body') {
+                    if (t.id) {
+                        elm += `.${t.id}`;
                     }
-                    e = t;
+                    p.unshift(elm);
                 }
             }
+
+            if (!e && matches(s)) {
+                if (t.tagName.toLowerCase() === 'a') {
+                    c = 'link';
+                } else {
+                    c = t.tagName.toLowerCase();
+                }
+                e = t;
+            }
+
             t = t.parentNode;
         }
         if (e && p.length > 0) {
@@ -137,7 +148,7 @@ export default class Utils {
         if ('performance' in window.parent) {
             let p = window.parent.performance;
             if ('getEntriesByType' in p) {
-                let navs = p.getEntriesByType("navigation");
+                let navs = p.getEntriesByType('navigation');
                 if(navs.length >= 1) {
                     nav.type = navs[0].type;
                     nav.redirectCount = navs[0].redirectCount;
@@ -145,7 +156,7 @@ export default class Utils {
                 }
             }
             if ('getEntriesByName' in p) {
-                let paints = p.getEntriesByName("first-paint");
+                let paints = p.getEntriesByName('first-paint');
                 if(paints.length >= 1) {
                     nav.first_paint = paints[0].startTime;
                 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -68,7 +68,10 @@ export default class Utils {
                 let elm = t.tagName.toLowerCase();
                 if (elm !== 'html' && elm !== 'body') {
                     if (t.id) {
-                        elm += `.${t.id}`;
+                        elm += `#${t.id}`;
+                    }
+                    if (t.className) {
+                        elm += `.${t.className}`;
                     }
                     p.unshift(elm);
                 }


### PR DESCRIPTION
Today's ATJ measures click events on elements with data-attribute specified in targetAttribute option. With some sites, analysts want to measure clicks on all clickable elements without additional tagging work. This update contains the auto-track feature for click events on all clickable elements.

Original ATJ requires a `trackClick.targetAttribute` option for specifying the target element of trackClick. With this new auto-track feature, if  `trackClick.targetAttribute` is not specified, clicks on all clickable elements will be measured. So, the implementation work can be reduced.