### PR TITLE
Check existence of element attribute before track click.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -388,7 +388,7 @@ export default class AtlasTracking {
             const targetAttribute = obj.trackClick && obj.trackClick.targetAttribute ? obj.trackClick.targetAttribute : false;
             const targetElement = this.utils.qsM('a, button, [role="button"]', ev.target, targetAttribute);
 
-            if(targetElement){
+            if(targetElement && targetElement.element){
 
                 let elm = targetElement.element;
                 let ext = (elm.pathname || '').match(/.+\/.+?\.([a-z]+([?#;].*)?$)/);


### PR DESCRIPTION
Current code tracks click events on every DOM. But every element does not have `element` attributes.
This PR introduce filtering condition before tracking click.