### PR TITLE
Fix `name` attr which is permanently `undefined` since 2.14

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -450,7 +450,7 @@ export default class AtlasTracking {
                                     attr,
                                     {
                                         'location': targetElement.pathTrackable,
-                                        'name': undefined
+                                        'name': elm.getAttribute(targetAttribute)
                                     }
                                 )
                             });


### PR DESCRIPTION
We changed the behavior of `clickTrack` for auto-track at ver 2.14.
However, there was a small glitch.

**Before 2.14**
If the clickTrack is enabled with `data-atlas-trackable` attribute, `ingest.context.action.name` will contain a value of the attribute.

**Since 2.14**
If the clickTrack is enabled without `data-atlas-trackable` attribute, all clicks on clickable element is tracked automatically & `ingest.context.action.name` will be removed (set `undefined` internally)

Even if the clickTrack is enabled with `data-atlas-trackable` attribute, `ingest.context.action.name` will be removed (set `undefined` internally)

**This PR**
If the clickTrack is enabled with `data-atlas-trackable` attribute, `ingest.context.action.name` will contain a value of the attribute. (same with pre-2.14)