### PR TITLE
Call `new AbortController()` on the checked object properly.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -466,9 +466,10 @@ export default class Utils {
             }
             return true;
         } else {
-            if (('fetch' in this.targetWindow && typeof this.targetWindow.fetch === 'function')
-                && ('AbortController' in this.targetWindow && typeof this.targetWindow.AbortController === 'function')) {
-                const controller = new AbortController();
+            const targetWindow = this.targetWindow;
+            if (('fetch' in targetWindow && typeof targetWindow.fetch === 'function')
+                && ('AbortController' in targetWindow && typeof targetWindow.AbortController === 'function')) {
+                const controller = new targetWindow.AbortController();
                 const signal = controller.signal;
                 setTimeout(() => controller.abort(), atlasBeaconTimeout);
                 try{


### PR DESCRIPTION
If the case of `(this.contentWindow === this)` is `false`, The previous code fail to evaluate `new AbortController()` because there is no `this.AbortController`.

For example, this issue would be happen if the user introduce `AbortController` as a polyfill to `this.contentWindow` but it's not loaed to `this`.

This original code path was introduced in https://github.com/Nikkei/atlas-tracking-js/commit/4141ebe740c9796027e73f818c3433a4271299a9. So this bug is exist from that time.