### PR TITLE
Fixed a function for reading Cookie

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -100,8 +100,18 @@ export default class Utils {
     }
 
     getC(k) {
-        const cookies = this.targetWindow.document.cookie || '';
-        return ((`; ${cookies};`).match(`; ${k}=([^¥S;]*)`) || [])[1] || '';
+        const cookies = this.targetWindow.document.cookie.split(';');
+        for(let i = 0; i < cookies.length; i++) {
+            let cookie = cookies[i];
+            while (cookie.charAt(0) == ' ') {
+                cookie = cookie.substring(1, cookie.length);
+            }
+            if (cookie.indexOf(`${k}=`) == 0) {
+                return cookie.substring(`${k}=`.length, cookie.length);
+            }else{
+                return '';
+            }
+        }
     }
 
     getQ(k) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,10 +103,10 @@ export default class Utils {
         const cookies = this.targetWindow.document.cookie.split(';');
         for(let i = 0; i < cookies.length; i++) {
             let cookie = cookies[i];
-            while (cookie.charAt(0) == ' ') {
+            while (cookie.charAt(0) === ' ') {
                 cookie = cookie.substring(1, cookie.length);
             }
-            if (cookie.indexOf(`${k}=`) == 0) {
+            if (cookie.indexOf(`${k}=`) === 0) {
                 return cookie.substring(`${k}=`.length, cookie.length);
             }else{
                 return '';


### PR DESCRIPTION
A function for reading Cookie in `util.js` has a bug; it truncates a value after string `S` because of wrong RegEx.
This bug is a potential cause of the shorter Atlas ID.