### PR TITLE
Fix a bug in the new Cookie Read function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -108,10 +108,9 @@ export default class Utils {
             }
             if (cookie.indexOf(`${k}=`) === 0) {
                 return cookie.substring(`${k}=`.length, cookie.length);
-            }else{
-                return '';
             }
         }
+        return '';
     }
 
     getQ(k) {


### PR DESCRIPTION
The new cookie read function `getC()` in utils does not return a correct value of Cookie.
This PR is to fix it.