### PR TITLE
Fix a condition for triggering Click Tracking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -432,7 +432,7 @@ export default class AtlasTracking {
                 }
 
                 // Click
-                if (targetElement && obj.trackClick.enable) {
+                if (obj.trackClick && obj.trackClick.enable && targetElement) {
                     if(!obj.trackClick.targetAttribute){
                         this.utils.transmit('click', targetElement.category, user, context, {
                             'action': Object.assign(


### PR DESCRIPTION
With ATJ 2.15.x, unexpected script error happened if `trackClick` option is not set.
A root cause is `delegateClickEvents()` does not evaluate that `trackClick` option exists or not.
So, this PR is to add  a condition to check `trackClick` option which is the  parent of `obj.trackClick.enable`.
