### PR TITLE
fix: When the build target is ES2015, this give us TypeError.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ export default class AtlasTracking {
         defaults.product = obj.product.productName !== void 0 ? obj.product.productName : null;
 
         this.utils = new Utils(targetWindow);
-        this.eventHandler = this.utils.handler;
+        this.eventHandler = this.utils.handler();
 
         if ('onbeforeunload' in targetWindow) {
             unloadEvent = 'beforeunload';

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ export default class AtlasTracking {
         defaults.product = obj.product.productName !== void 0 ? obj.product.productName : null;
 
         this.utils = new Utils(targetWindow);
-        this.eventHandler = new this.utils.handler;
+        this.eventHandler = this.utils.handler;
 
         if ('onbeforeunload' in targetWindow) {
             unloadEvent = 'beforeunload';


### PR DESCRIPTION
This doesn't raise an error when the build target is es5 since `class` will become prototype base object.
However, when the build is ES2015 onward this will raise an error.
This is kinda OK when users of this JavaScript are transpiling es5, but when it's not. (and likely-hood this happens will be high since IE11 is officially not supported anymore)