### PR TITLE
Added a fallback for IE compatibility

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -21,11 +21,19 @@ let sendBeaconStatus = true;
 export default class Utils {
     constructor(targetWindow) {
         const timestamp = (+new Date()).toString(16);
-        const u32a = new Uint32Array(3);
         let result = '';
-        self.crypto.getRandomValues(u32a);
-        for (const num of u32a) {
-            result += num.toString(32)
+        if (self.crypto.getRandomValues) {
+            const u32a = new Uint32Array(3);
+            self.crypto.getRandomValues(u32a);
+            for (const num of u32a) {
+                result += num.toString(32);
+            }
+        }else{
+            // For IE compatibility
+            const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+            for (let i = 0; i < 32; i++) {
+                result += chars[Math.floor(Math.random() * chars.length)];
+            }
         }
         this.uniqueId = `${timestamp}.${result}`;
         this.targetWindow = targetWindow;

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,7 +22,7 @@ export default class Utils {
     constructor(targetWindow) {
         const timestamp = (+new Date()).toString(16);
         let result = '';
-        if (self.crypto.getRandomValues) {
+        if (self.crypto && self.crypto.getRandomValues) {
             const u32a = new Uint32Array(3);
             self.crypto.getRandomValues(u32a);
             for (const num of u32a) {


### PR DESCRIPTION
IE does not support `crypto.getRandomValues()` so the unique ID generation using `Math.random()` is still needed.
This PR is to add a condition like `if (self.crypto.getRandomValues) {}else{}`to split the process based on the browser supports `getRandomValues` or not.