### PR TITLE
Update build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:15.11.0-alpine
+FROM node:lts-alpine
 
 RUN mkdir -p /var/atj
 
 ADD ./ /var/atj
 WORKDIR /var/atj
 
-RUN apk add python make g++ openjdk8-jre chromium grep
+RUN apk add python3 make g++ openjdk8-jre chromium grep
 
 ENV PATH $PATH:/var/atj/node_modules
 


### PR DESCRIPTION
- Use the long term support (LTS) version of Node.js
- Use the latest Docker image with Alpine
- Specified `python3` instead of `python`