### PR TITLE
Add "Last Click" feature

### DIFF
--- a/dist/c2p.js
+++ b/dist/c2p.js
@@ -10,7 +10,6 @@
                 'endpoint': 'CHANGE_ME',
                 'apiKey': 'CHANGE_ME',
                 'beaconTimeout': 2000,
-                'cookieName': 'atlasId',
                 'cookieMaxAge': (2 * 365 * 24 * 60 * 60),
                 'cookieDomain': 'CHANGE_ME',
                 'targetWindow': 'self'
@@ -28,6 +27,10 @@
                 'trackClick': {
                     'enable': true,
                     'targetAttribute': 'data-atlas-trackable',
+                    'disableText': false,
+                    'logLastClick': true,
+                    'lastClickTtl': 5,
+                    'useLastClickOnly': false,
                 },
                 'trackLink': {
                     'enable': true,

--- a/docs/CONFIGURATION-JP.md
+++ b/docs/CONFIGURATION-JP.md
@@ -39,7 +39,7 @@
 |endpoint|String|ATJがビーコンを送る宛先|`atlas-endpoint.your.domain`|
 |apiKey|String|エンドポイントはこのキーを持つビーコンを受け付ける|`abc123xyz789`|
 |beaconTimeout|Integer|エンドポイントとの通信タイムアウトをミリ秒で指定|`2000` (2 sec)|
-|cookieName|String|Atlas IDを保存するCookie名|`atlasId`|
+|cookieName|String| **廃止** Atlas IDを保存するCookie名|`atlasId`|
 |cookieMaxAge|Integer|Atlas IDのCookieの有効期間|`(2 * 365 * 24 * 60 * 60)` (2 years)|
 |cookieDomain|String|Cookieを保存する際にドメイン属性として利用するドメイン名|`your.domain`|
 |targetWindow|String|ATJが動く（相対的な）ウィンドウ名|`parent`| 
@@ -96,9 +96,14 @@
 |:----:|:----:|:----:|:----:|
 |trackClick.enable|Boolean|この機能を使うか否か|`true`|
 |trackClick.targetAttribute|String|ATJはユーザーがこのデータ属性を持つ要素をクリックしたときにデータを収集する|`data-atlas-trackable`|
+|trackClick.disableText|Boolean|クリックされた要素の文字列の記録を無効化するか否か|`false`|
+|trackClick.logLastClick|Boolean|クリックに関する情報を次のページに引き継ぎ遷移先で直前のクリックを計測する|`true`|
+|trackClick.lastClickTtl|Integer|直前のクリックについての情報の有効期間（秒）|`5`|
+|trackClick.useLastClickOnly|Boolean|直前のクリック計測のみを利用し、クリックイベント時の計測を無効化するか否か|`false`|
 
 - `enable` が `true` であり、 `targetAttribute` に何らかの値が指定されている場合、 `targetAttribute` に指定されたdata属性を持つ要素のみが計測対象となる
 - `enable` が `true` であり、 `targetAttribute` が未指定または `false` の場合、全てのクリッカブル要素が計測対象となる
+- `logLastClick` を用いる場合、 Session Storage にキー名 `atlasLastClick` でJSON文字列が格納される（次ページで削除される）
 
 #### trackLink (オプション以下)
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,7 +13,6 @@ Most variables except `system` can be omitted but strongly recommend to specify 
     'defaults': {...},
     'product': {...},
     'options': {
-        'useGet': true,
         'exchangeAtlasId': {...},
         'trackClick': {...},
         'trackLink': {...},
@@ -40,7 +39,7 @@ Most variables except `system` can be omitted but strongly recommend to specify 
 |endpoint|String|Destination which ATJ transmit beacons to|`atlas-endpoint.your.domain`|
 |apiKey|String|Atlas Endpoint will accept beacons having this key|`abc123xyz789`|
 |beaconTimeout|Integer|Time limit in milli sec to cancel the connection to the endpoint |`2000` (2 sec)|
-|cookieName|String|Cookie name to store Atlas ID|`atlasId`|
+|cookieName|String| **DEPRECATED** Cookie name to store Atlas ID|`atlasId`|
 |cookieMaxAge|Integer|Atlas ID Cookie lifetime|`(2 * 365 * 24 * 60 * 60)` (2 years)|
 |cookieDomain|String|Domain to be used as domain-attribute when ATJ set Atlas ID Cookie|`your.domain`|
 |targetWindow|String|A name of (relative) target window where ATJ work in|`parent`| 
@@ -97,9 +96,14 @@ Most variables except `system` can be omitted but strongly recommend to specify 
 |:----:|:----:|:----:|:----:|
 |trackClick.enable|Boolean|Use this feature or not|`true`|
 |trackClick.targetAttribute|String|ATJ collects data when user clicked elements which has this data attribution |`data-atlas-trackable`|
+|trackClick.disableText|Boolean|If `true`, ATJ won't send a text on clicked element|`false`|
+|trackClick.logLastClick|Boolean|Inherit click information to the next page for Last Click feature|`true`|
+|trackClick.lastClickTtl|Integer|TTL in Sec about how long ATJ keep the last click information|`5`|
+|trackClick.useLastClickOnly|Boolean|If `true`, ATJ use only Last Click, and disable beacons on click event|`false`|
 
 - If `enable` is `true` and `targetAttribute` has a value, elements with data-attribute specified as `targetAttribute` is tracked.
 - If `enable` is `true` but `targetAttribute` is not specified or has `false`, all clickable elements are tracked.
+- In case `logLastClick` is enabled, a JSON string with key name `atlasLastClick` is added to Session Storage. (this item will be deleted on next page)
 
 #### trackLink (under options)
 

--- a/src/index.js
+++ b/src/index.js
@@ -277,22 +277,19 @@ export default class AtlasTracking {
 
             if(options.trackClick.logLastClick){
                 const ttl = options.trackClick.lastClickTtl || 5;
-                const atlasLastClickJson = sessionStorage.getItem(lastClickStorageKey);
+                let atlasLastClickJson = '';
                 let atlasLastClickObj = {};
 
                 try{
+                    atlasLastClickJson = sessionStorage.getItem(lastClickStorageKey);
                     atlasLastClickObj = JSON.parse(atlasLastClickJson) || {};
+                    sessionStorage.removeItem(lastClickStorageKey);
                 }catch(e){
                     // Nothing to do
                 }
 
                 if((Date.now() - atlasLastClickObj.ts) <= (ttl * 1000)){
-                    try{
-                        context.last_click = atlasLastClickObj.attr;
-                        sessionStorage.removeItem(lastClickStorageKey);
-                    }catch(e){
-                        // Nothing to do
-                    }
+                    context.last_click = atlasLastClickObj.attr;
                 }
             }            
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,10 +112,6 @@ export default class Utils {
         if(attributeName){
             result = element.getAttribute(attributeName);
         }
-
-        this.targetWindow.console.log(element);
-        this.targetWindow.console.log(attributeName);
-        this.targetWindow.console.log(result);
         if(result === null) {
             result = undefined;
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,16 @@
 'use strict';
 
 // SDK Version Info
-const SDK_NAME = 'ATJ';
 const SDK_VERSION = process.env.npm_package_version;
 const SDK_API_KEY = process.env.SDK_API_KEY || 'test_api_key';
 const DEFAULT_ENDPOINT = process.env.DEFAULT_ENDPOINT || 'atlas.local';
 
+const sdkName = 'ATJ';
+const atlasCookieName = 'atlasId';
+
 let atlasEndpoint = null;
 let atlasApiKey = null;
 let atlasBeaconTimeout = null;
-let atlasCookieName = null;
 let atlasId = '0';
 let handlerEvents = {};
 let handlerKey = 0;
@@ -43,7 +44,6 @@ export default class Utils {
         atlasEndpoint = system.endpoint ? system.endpoint : DEFAULT_ENDPOINT;
         atlasApiKey = system.apiKey ? system.apiKey : SDK_API_KEY;
         atlasBeaconTimeout = system.beaconTimeout ? system.beaconTimeout : 2000;
-        atlasCookieName = system.cookieName ? system.cookieName : 'atlasId';
 
         atlasId = this.getC(atlasCookieName);
 
@@ -105,6 +105,21 @@ export default class Utils {
             'pathDom': pd.join('>')
         };
 
+    }
+
+    getAttr(attributeName, element) {
+        let result = null;
+        if(attributeName){
+            result = element.getAttribute(attributeName);
+        }
+
+        this.targetWindow.console.log(element);
+        this.targetWindow.console.log(attributeName);
+        this.targetWindow.console.log(result);
+        if(result === null) {
+            result = undefined;
+        }
+        return result;
     }
 
     getC(k) {
@@ -446,7 +461,7 @@ export default class Utils {
         }
 
         let b = JSON.stringify(this.buildIngest(ur, ct, sp));
-        let u = `https://${atlasEndpoint}/${SDK_NAME}-${SDK_VERSION}/${now}/${encodeURIComponent(atlasId)}/${f}`
+        let u = `https://${atlasEndpoint}/${sdkName}-${SDK_VERSION}/${now}/${encodeURIComponent(atlasId)}/${f}`
             + `/ingest?k=${atlasApiKey}&a=${ac}&c=${ca}&aqe=%`
             + `&d=${this.compress(encodeURIComponent(b))}`; //endpointUrl
 


### PR DESCRIPTION
# Last Click measurement

- Last Click feature is a solution for mis-tracking issue of beacons while unload event (especialy on Safari).
  - ATJ's conventional click tracking send a beacon on click event, but some browsers in some cases, script & beacon may be canceled.
  - Another method with link decorator (like adding `?cid=` param) is not recommended from SEO perspective (canonnical URL problem)

- How this work
  - the Last Click feature stores information about clicked element into Session Storage when the click event occurred. 
  - on the next page, ATJ read nformation from Session Storage, then add it under `context.last_click`.

# Minor improvements

- removed `cookieName` option because  no one use this.
- optimized logic in click event handler
- bug fix for Download click
