### PR TITLE
Bug Fix: added page_title field which is removed unexpectedly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -266,6 +266,7 @@ export default class AtlasTracking {
         if (paramContext !== void 0) {
             context = paramContext;
             context.root_id = this.utils.getUniqueId();
+            context.page_title = paramContext.page_title !== void 0 ? paramContext.page_title : defaults.page_title;
             context.url = paramContext.url !== void 0 ? paramContext.url : defaults.url;
             context.referrer = paramContext.referrer !== void 0 ? paramContext.referrer : defaults.referrer;
             context.product_family = paramContext.product_family || defaults.product_family;


### PR DESCRIPTION
In the release of 2.16.*, some code that generates the ingest object has been minimized by reducing redundant scripts.
At that moment, we deleted a line for defining `ingest.context.page_name` accidentaly, then it affects lack of page_title from the log.
So, I'd like to re-add that necessary code. (restoring)