### PR TITLE
Bug Fix) Added a trigger condition on click measurement 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules
 test/integration/pages/assets/*.js
 dist/atj.js
 dist/atj.min.js
+dist/atj.zip
 dist/index.html
 test/build

--- a/src/index.js
+++ b/src/index.js
@@ -435,24 +435,27 @@ export default class AtlasTracking {
                         attr['location'] = targetElement.pathTrackable;
                     }
 
-                    // Last Click
-                    if(obj.trackClick.logLastClick){
-                        try{
-                            sessionStorage.setItem(lastClickStorageKey, JSON.stringify({
-                                ts: Date.now(),
-                                attr: attr
-                            }));
-                        }catch(e){
-                            // Nothing to do
+                    if(!targetAttribute || targetAttribute && elm.attributes[targetAttribute]){
+                        // Last Click
+                        if(obj.trackClick.logLastClick){
+                            try{
+                                sessionStorage.setItem(lastClickStorageKey, JSON.stringify({
+                                    ts: Date.now(),
+                                    attr: attr
+                                }));
+                            }catch(e){
+                                // Nothing to do
+                            }
+                        }
+
+                        // If useLastClickOnly is false
+                        if(!obj.trackClick.useLastClickOnly){
+                            this.utils.transmit('click', targetElement.category, user, context, {
+                                'action': attr
+                            });
                         }
                     }
 
-                    // If useLastClickOnly is false
-                    if(!obj.trackClick.useLastClickOnly){
-                        this.utils.transmit('click', targetElement.category, user, context, {
-                            'action': attr
-                        });
-                    }
                 }
             }
         }, false);


### PR DESCRIPTION
This PR is to fix a bug in click measurement feature.

ATJ must send a beacon in case of following:
- `click.enable` is `true` AND  `click.targetAttribute` is not specified ( `undefined` or `false` )
- `click.enable` is `true` AND `click.targetAttribute` is specified AND the clicked element has an attribute specified as `targetAttribute`

However, as of now, ATJ send a beacon when `click.enable` is `true` AND  `click.targetAttribute` is specified AND the clicked element has no attribute eg. `data-atlas-trackable`. This behavior is unexpected and was inserted in the last version-up.

So, we need to fix this bug:

* `targetAttribute` is set as `data-atlas-trackable`

| click.enable | click.targetAttribute | expected | actual |
|:----|:----|:----|:----|
| `true` | `data-atlas-trackable` | triggered | triggered |
| `true` | `data-dummy` | nothing | **triggered** |
| `true` | `undefined` | triggered | triggered |
| `false` | `data-atlas-trackable` | nothing | nothing |
| `false` | `data-dummy` | nothing | nothing |
| `false` | `undefined` | nothing | nothing |

To do this, added a trigger condition into `delegateClickEvents` method.