### PR TITLE
`pageLoadedAt` must be reset by initPage()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,9 +28,9 @@ let eventHandlerKeys = {
     form: {}
 };
 
-let pageLoadedAt = Date.now();
-let prevActionOccurredAt = pageLoadedAt;
-
+let isInitialized = false;
+let pageLoadedAt, prevActionOccurredAt;
+pageLoadedAt = prevActionOccurredAt = Date.now();
 
 export default class AtlasTracking {
     constructor() {
@@ -258,6 +258,13 @@ export default class AtlasTracking {
     initPage(obj) {
         const paramUser = obj.user;
         const paramContext = obj.context;
+
+        if(isInitialized){
+            pageLoadedAt = prevActionOccurredAt = Date.now();
+        }else{
+            isInitialized = true;
+        }
+
         if (paramUser !== void 0) {
             user = paramUser;
             user.custom_object = paramUser.custom_object || {};


### PR DESCRIPTION
With Single Page Application (SPA), `initPage()` is called when the view is changed (eg. `onHashChange` ).
However, internal variables `pageLoadedAt` and `prevActionOccurredAt` are not reset by `initPage()`.
This causes a larger `elapsed_since_page_load` value than expected, in some variables under `ingest` object.

This PR is to add a code for resetting both `pageLoadedAt` and `prevActionOccurredAt` when the 2nd `initPage()` and later.