### PR TITLE
Keep `pathDom` when `pathTrackable` is not provided

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -444,7 +444,10 @@ export default class AtlasTracking {
                     ){
                         attr['name'] = targetAttribute ? this.utils.getAttr(trackClickConfig.targetAttribute, elm) : undefined;
                         attr['text'] = !trackClickConfig.disableText ? (elm.innerText || elm.value || '').substr(0,63) : undefined;
-                        attr['location'] = targetElement.pathTrackable.length > 0 ? targetElement.pathTrackable : undefined;
+
+                        if(targetElement.pathTrackable.length > 0){
+                            attr['location'] = targetElement.pathTrackable;
+                        }
 
                         // Last Click
                         if(trackClickConfig.logLastClick){


### PR DESCRIPTION
ATJ 2.16.6 added ability to enable both click measurement 1. semi-auto tracking with `data-trackable` and 2. full-auto tracking with `logAllClicks` option at the same time.
However, `ingest.context.action.location` is enexpectedly `undefined` when the full-auto is enabled and the element has `data-trackable` attribute.
This is caused by a bug in `delegateClickEvents()`. If `pathTrackable` is not provided, the value of `pathDom` should be kept.
So, this PR is to fix this bug.