### PR TITLE
Update configuration documents to be consistent with the code

### DIFF
--- a/docs/CONFIGURATION-JP.md
+++ b/docs/CONFIGURATION-JP.md
@@ -40,8 +40,8 @@
 |apiKey|String|エンドポイントはこのキーを持つビーコンを受け付ける|`abc123xyz789`|
 |beaconTimeout|Integer|エンドポイントとの通信タイムアウトをミリ秒で指定|`2000` (2 sec)|
 |cookieName|String| **廃止** Atlas IDを保存するCookie名|`atlasId`|
-|cookieMaxAge|Integer|Atlas IDのCookieの有効期間|`(2 * 365 * 24 * 60 * 60)` (2 years)|
-|cookieDomain|String|Cookieを保存する際にドメイン属性として利用するドメイン名|`your.domain`|
+|cookieMaxAge|Integer| **廃止** Atlas IDのCookieの有効期間|`(2 * 365 * 24 * 60 * 60)` (2 years)|
+|cookieDomain|String| **廃止** Cookieを保存する際にドメイン属性として利用するドメイン名|`your.domain`|
 |targetWindow|String|ATJが動く（相対的な）ウィンドウ名|`parent`| 
 
 #### defaults

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -40,8 +40,8 @@ Most variables except `system` can be omitted but strongly recommend to specify 
 |apiKey|String|Atlas Endpoint will accept beacons having this key|`abc123xyz789`|
 |beaconTimeout|Integer|Time limit in milli sec to cancel the connection to the endpoint |`2000` (2 sec)|
 |cookieName|String| **DEPRECATED** Cookie name to store Atlas ID|`atlasId`|
-|cookieMaxAge|Integer|Atlas ID Cookie lifetime|`(2 * 365 * 24 * 60 * 60)` (2 years)|
-|cookieDomain|String|Domain to be used as domain-attribute when ATJ set Atlas ID Cookie|`your.domain`|
+|cookieMaxAge|Integer| **DEPRECATED** Atlas ID Cookie lifetime|`(2 * 365 * 24 * 60 * 60)` (2 years)|
+|cookieDomain|String| **DEPRECATED** Domain to be used as domain-attribute when ATJ set Atlas ID Cookie|`your.domain`|
 |targetWindow|String|A name of (relative) target window where ATJ work in|`parent`| 
 
 #### defaults


### PR DESCRIPTION
# Summary
In the [System Table in CONFIGURATION.md](https://github.com/Nikkei/atlas-tracking-js/blob/master/docs/CONFIGURATION.md#system), the `Purpose` column for the `cookieDomain` property, which is no longer used, is marked as **`DEPRECATED`**.

However, `cookieMaxAge` and `cookieDomain` are not currently used either, but they are not marked as deprecated.

So in this PR, I have changed the documentation to be consistent with the current code.