### PR TITLE
Fix typos in Japanese documentation

### DIFF
--- a/docs/CONFIGURATION-JP.md
+++ b/docs/CONFIGURATION-JP.md
@@ -168,7 +168,7 @@
 |trackRead.milestones|Array|ATJはまた、これらのマイルストーンを越えた時点でビーコンを送信する|`[4, 15, 30, 60, 90, 120]`|
 
 - `trackScroll` と `trackRead` の違いは：
-    - `trackScroll` はwindowに対するスクロース深度を計測する
+    - `trackScroll` はwindowに対するスクロール深度を計測する
     - `trackRead` はコンテンツ本体のブロック要素における可視性の変化に注目する
 - `trackScroll` は深度と時間の組み合わせで動くが、 `trackRead` は深度と時間を切り離して扱う
 

--- a/docs/METHODS-JP.md
+++ b/docs/METHODS-JP.md
@@ -259,7 +259,7 @@ atlasTracking.delCustomId('rtoaster');
 |detail.targetHeight|Float|対象要素の高さのピクセルまたはポイント（iOS）|`269`|
 |detail.targetMarginTop|Float|viewportの上端から対象要素の上端までの距離|`455.03125`|
 |detail.targetMarginBottom|Float|viewportの下端から対象要素の下端までの距離|`169.96875`|
-|detail.targetScrollRate|Float|対象要素に対する可視領域のスクロース率。1の場合は対象要素の下端まで見えているという意味|`1`|
+|detail.targetScrollRate|Float|対象要素に対する可視領域のスクロール率。1の場合は対象要素の下端まで見えているという意味|`1`|
 |detail.targetScrollUntil|Float|対象要素のスクロール深度|`269`|
 |detail.targetViewableRate|Float|対象要素の可視領域の割合|`1`|
 |detail.targetVisibleTop|Float|対象要素の可視領域の上端位置|`0`|


### PR DESCRIPTION
This pull request addresses a couple of typos in the Japanese documentation where "スクロール" was mistakenly typed as "スクロース." The affected instances have been corrected to "スクロール"