### PR TITLE
Add description for click auto track (lack of documentation)

### DIFF
--- a/docs/CONFIGURATION-JP.md
+++ b/docs/CONFIGURATION-JP.md
@@ -100,9 +100,11 @@
 |trackClick.logLastClick|Boolean|クリックに関する情報を次のページに引き継ぎ遷移先で直前のクリックを計測する|`true`|
 |trackClick.lastClickTtl|Integer|直前のクリックについての情報の有効期間（秒）|`5`|
 |trackClick.useLastClickOnly|Boolean|直前のクリック計測のみを利用し、クリックイベント時の計測を無効化するか否か|`false`|
+|trackClick.logAllClicks|Boolean|全てのクリックを強制的に計測する。データ属性の指定と完全な自動計測を両立する|`true`|
 
 - `enable` が `true` であり、 `targetAttribute` に何らかの値が指定されている場合、 `targetAttribute` に指定されたdata属性を持つ要素のみが計測対象となる
 - `enable` が `true` であり、 `targetAttribute` が未指定または `false` の場合、全てのクリッカブル要素が計測対象となる
+- `enable` が `true` であり、 `targetAttribute` に何らかの値が指定され、かつ `logAllClicks` が存在し `true`がセットされている場合、全てのクリックが `targetAttribute` で指定されたdata属性により命名された上で計測される
 - `logLastClick` を用いる場合、 Session Storage にキー名 `atlasLastClick` でJSON文字列が格納される（次ページで削除される）
 
 #### trackLink (オプション以下)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -100,9 +100,11 @@ Most variables except `system` can be omitted but strongly recommend to specify 
 |trackClick.logLastClick|Boolean|Inherit click information to the next page for Last Click feature|`true`|
 |trackClick.lastClickTtl|Integer|TTL in Sec about how long ATJ keep the last click information|`5`|
 |trackClick.useLastClickOnly|Boolean|If `true`, ATJ use only Last Click, and disable beacons on click event|`false`|
+|trackClick.logAllClicks|Boolean|If `true` then force to log all clicks. It allows both fully automated click tracking and naming events through data attribute|`true`|
 
 - If `enable` is `true` and `targetAttribute` has a value, elements with data-attribute specified as `targetAttribute` is tracked.
 - If `enable` is `true` but `targetAttribute` is not specified or has `false`, all clickable elements are tracked.
+- If  `enable` is `true` and `targetAttribute`, but `logAllClicks` is available and set to `true`, all clicks will be tracked with custome naming by data attribute specified as `targetAttribute`.
 - In case `logLastClick` is enabled, a JSON string with key name `atlasLastClick` is added to Session Storage. (this item will be deleted on next page)
 
 #### trackLink (under options)


### PR DESCRIPTION
- ATJ supports `logAllClicks` option in Click Track, but it was not documented. This PR is to add the description of this option.