### PR TITLE
Reduce for ~ of polyfill

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -339,14 +339,14 @@ export default class AtlasTracking {
         }
         if (options.trackMedia && options.trackMedia.enable) {
             const targetEvents = ['play', 'pause', 'end'];
-            for (const event of targetEvents) {
-                this.eventHandler.remove(eventHandlerKeys['media'][event]);
+            for (let i = 0; i < targetEvents.length; i++) {
+                this.eventHandler.remove(eventHandlerKeys['media'][targetEvents[i]]);
             }
         }
         if (options.trackForm && options.trackForm.enable && options.trackForm.target !== null) {
             const targetEvents = ['focus', 'change'];
-            for (const event of targetEvents) {
-                this.eventHandler.remove(eventHandlerKeys['form'][event]);
+            for (let i = 0; i < targetEvents.length; i++) {
+                this.eventHandler.remove(eventHandlerKeys['form'][targetEvents[i]]);
             }
         }
         if (options.trackPerformance && options.trackPerformance.enable) {


### PR DESCRIPTION
just a small change;
- `for( ~ of ~)` syntax is not supported in ES5 so the build script source a stiny polyfill code
- In the source code, there are both `for()` and `for( ~ of ~)`, but no policy here (I guess). So I suggest to reduce `for( ~ of ~)` use for reducing the bundle size smaller as possibule.