### PR TITLE
perf: Remove `for-of` in Utils to eliminate polyfill

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -35,8 +35,8 @@ export default class Utils {
         if (self.crypto && self.crypto.getRandomValues) {
             const u32a = new Uint32Array(3);
             self.crypto.getRandomValues(u32a);
-            for (const num of u32a) {
-                result += num.toString(32);
+            for (let i = 0; i < u32a.length; i++) {
+                result += u32a[i].toString(32);
             }
         }else{
             // For IE compatibility


### PR DESCRIPTION
PR #136 attempted to remove `for-of` syntax to prevent its polyfill from being included in the bundled code. However, `for-of` was still being used in Utils, which is why the polyfill remained in the bundle.

In this PR, I replaced the `for-of` loops in Utils with index-based iteration. With this change, the polyfill for `for-of` syntax has been removed from the bundled file, resulting in a 1kiB reduction in bundle size

| Before | After |
| ---- | ---- |
| <img width="545" alt="image" src="https://github.com/user-attachments/assets/242d7f88-7b82-4be6-9b5f-8a6cbc53cf30"/> | <img width="524" alt="image" src="https://github.com/user-attachments/assets/8e73eced-6ca7-4da9-976b-5a6d4395b476"/>
