### PR TITLE
docs: update README to replace npm instructions with pnpm

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -47,16 +47,16 @@ docker run \
 
 #### 初期設定
 ```sh
-npm install
+pnpm install
 ```
 
 ### テスト
-- 構文チェックは `npm run eslint` でできます
-- ユニットテストを行う場合は `npm run test` を実行
+- 構文チェックは `pnpm run eslint` でできます
+- ユニットテストを行う場合は `pnpm run test` を実行
 
 ### ビルド
-- スタンドアロンのATJは `npm run build:dist` （一般的に、これはほとんどの用途に適合します）
-- NPMモジュールを生成する場合は, `npm run build:npm`
+- スタンドアロンのATJは `pnpm run build:dist` （一般的に、これはほとんどの用途に適合します）
+- NPMモジュールを生成する場合は, `pnpm run build:npm`
 
 ## 実装ガイド
 

--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ docker run \
 
 #### Initialization
 ```sh
-npm install
+pnpm install
 ```
 
 ### Test
-- You can lint the code by `npm run eslint`
-- For the unit test, run `npm run test`
+- You can lint the code by `pnpm run eslint`
+- For the unit test, run `pnpm run test`
 
 ### Build
-- For the standalone ATJ, `npm run build:dist` (In general, this will fit with most use cases)
-- For generating NPM module, `npm run build:npm`
+- For the standalone ATJ, `pnpm run build:dist` (In general, this will fit with most use cases)
+- For generating NPM module, `pnpm run build:npm`
 
 ## Implementation Guide
 


### PR DESCRIPTION
PR #134 migrated the package manager to pnpm, but the README still contained npm instructions

This PR replaces npm instructions with pnpm to reflect the current package manager