### PR TITLE
chore: pin GitHub Actions to a full length commit SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 14
+      exclude:
+        - "actions/*"
+        - "github/*"
+        - "dependabot/*"
+        - "Nikkei/*"
+        - "nikkei/*"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 10
       - run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 10
       - name: pnpm install, build:dist


### PR DESCRIPTION
## Summary
GitHub ActionsのSHA固定を行います。このPRは、レビュー完了後にレビュアーの方でマージしていただけると助かります。 また、GitHub Actionsの自動更新のためdependabot.ymlを追加します。

## Changes

### Updated workflow files:
  - `.github/workflows/build-and-test.yml`
  - `.github/workflows/release.yml`

### Added configuration files:
  - `.github/dependabot.yml` - GitHub Actionsの依存関係を自動更新


## Security
参照されたアクションが変更されないようにすることで、潜在的なサプライチェーン攻撃を防止します。
詳しくはこちら: https://www.notion.so/GitHub-Actions-208413ae5a6980ab9b88f57b353f0553

---
*このPRはツールによって自動作成されました。質問がある場合は Slack #security-faq でお尋ねください。この変更に関する開発プレゼン会でのアナウンスは https://nikkeilabs.qiita.com/shared/items/391d0942f21b337acf58 記載の 2025/06/17 開催分から確認できます。*