### PR TITLE
Change runner from ubuntu-latest to ubuntu-slim

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5


### PR DESCRIPTION
This pull request updates the CI configuration to use ubuntu-slim instead of ubuntu-latest for build and test jobs.
ubuntu-slim costs 1/4 of the per-minute price of ubuntu-latest, so switching to ubuntu-slim can reduce CI costs, especially for frequent workflows as in Dependabot-generated PRs (ref: https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/)
The current CI test complete within one minute, and I checked that  it also finishes within one minute when running on ubuntu-slim too.