### PR TITLE
Remove `message` event listener in `disableTracking`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -352,6 +352,9 @@ export default class AtlasTracking {
         if (options.trackPerformance && options.trackPerformance.enable) {
             targetWindow.removeEventListener('DOMContentLoaded', atlasDOMContentLoadedHandler);
         }
+        if (options.trackThroughMessage && options.trackThroughMessage.enable) {
+            targetWindow.removeEventListener('message', atlasMessageHandler);
+        }
 
         options = {};
     }


### PR DESCRIPTION
This PR adds the previously missing cleanup step for the `message` event listener within the `disableTracking` mthod
 Adding this ensures the application state is properly reset when the tracker is deactivated.