### PR TITLE
chore: add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,6 +3,9 @@ name: build-and-test
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build_dist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Address code scanning alerts (#1, #2) by adding explicit `permissions` to workflows that were using the default GITHUB_TOKEN without restriction.

Following the principle of least privilege:

- `build-and-test.yml`: `contents: read` — only needs checkout, build, and test
- `release.yml`: `contents: write` — required for creating releases and uploading assets

## Test plan

- [x] `build-and-test` workflow runs successfully on this PR
- [ ] `release.yml` to be verified on next tag push