### PR TITLE
fix: Configure dependency minimum age to 7 days (and enable renovate's auto merge)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 3am on monday"],
+  "labels": ["dependencies", "renovate"],
+  "packageRules": [
+    {
+      "description": "Delay updates to allow for community vetting of new releases",
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Automatically merge non-major updates for devDependencies",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "description": "Automatically merge patch updates for dependencies",
+      "matchUpdateTypes": ["patch"],
+      "matchDepTypes": ["dependencies"],
+      "automerge": true
+    },
+    {
+      "description": "Automatically merge non-major updates for GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
+      "automerge": true
+    },
+    {
+      "description": "Group all ESLint updates together",
+      "matchPackagePatterns": ["^eslint", "^@typescript-eslint/"],
+      "groupName": "eslint"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "packageRules": [
     {
       "description": "Delay updates to allow for community vetting of new releases",
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "minimumReleaseAge": "7 days"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,7 @@
     },
     {
       "description": "Group all ESLint updates together",
-      "matchPackagePatterns": ["^eslint", "^@typescript-eslint/"],
+      "matchPackagePatterns": ["^eslint", "^@eslint/"],
       "groupName": "eslint"
     }
   ]


### PR DESCRIPTION
To improve the security for supply-chain attack, this PR is to configure minAge for NPM packages and other dependencies such as GitHub Actions.

- Added `pnpm-workspace.yaml` with minimum age 7 days (= 10080sec) setting
- Added `renovate.json` to define auto-merge policies and minimum age rule as 7 days