### PR TITLE
fix: `elapsed_since_prev_action` always returned 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -577,6 +577,7 @@ export default class AtlasTracking {
         const steps = 100 / each;
         let now = Date.now();
         let prev = now;
+        let prevVisible = now;
         let r = {}; //result
         let eiv = 0; //elapsedInVisible
         let cvr = 0; //currentViewRate
@@ -586,11 +587,11 @@ export default class AtlasTracking {
             r = this.utils.getV(target);
             if (r.detail.documentIsVisible !== 'hidden' && r.detail.documentIsVisible !== 'prerender' && r.status.isInView) {
                 now = Date.now();
-                if (now - prev >= 1000) {
-                    prev = now;
+                if (now - prevVisible >= 1000) {
+                    prevVisible = now;
                 }
-                eiv = eiv + (now - prev);
-                prev = now;
+                eiv = eiv + (now - prevVisible);
+                prevVisible = now;
 
                 // Milestone based
                 if(milestones.length > 0 && milestones[0] <= (eiv / 1000)){
@@ -607,6 +608,7 @@ export default class AtlasTracking {
                             'elapsed_since_prev_action': (now - prev) / 1000
                         }
                     });
+                    prev = now;
                     milestones.shift();
                 }
 
@@ -629,6 +631,7 @@ export default class AtlasTracking {
                             });
                             pvr = cvr;
                         }
+                        prev = now;
                     }, 1000);
                 }
             }


### PR DESCRIPTION
## Problem
`trackRead` reported `elapsed_since_prev_action: 0` on every event for both the `time` (milestone) and `scroll` modes. This issue causes because `prev = now` was executed at the end of the visibility-accumulation block, by the time `(now - prev)` was evaluated inside `transmit` (or inside the `setTimeout` closure for scroll mode), `prev` and `now` were always equal, producing `0`.

<img width="499" height="217" alt="image" src="https://github.com/user-attachments/assets/fd9caa16-1b35-4947-bdd3-bef673b10033" />


## Fix
- Introduce a dedicated `prevVisible` variable that handles the visible-time accumulation logic (replaces the old dual-use `prev`).
- Keep `prev` solely for tracking the last `transmit` timestamp, and update it **after** each `transmit` call:
  - Milestone mode: updated synchronously right after `transmit`.
  - Scroll mode: updated inside the `setTimeout` callback after `transmit`, matching the pattern already used in `trackScroll` and `trackInfinityScroll`.