### PR TITLE
Use local storage as atlas ID fallback

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -58,8 +58,10 @@ export default class Utils {
         atlasId = this.getC(atlasCookieName);
 
         if (!atlasId || atlasId === '0' || atlasId === 0 || atlasId === '1' || atlasId === 1 || atlasId.length < 5) {
-            atlasId =  this.uniqueId;
+            atlasId = this.getLS(atlasCookieName) || this.uniqueId;
         }
+
+        this.setLS(atlasCookieName, atlasId);
     }
 
     qsM(s, t, d = false) {
@@ -168,8 +170,16 @@ export default class Utils {
         } catch (e) {
             // Nothing to do...
         }
-        
+
         return r;
+    }
+
+    setLS(k, v) {
+        try {
+            this.targetWindow.localStorage[k] = v;
+        } catch (e) {
+            // Nothing to do...
+        }
     }
 
     getNav() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,1 +1,0 @@
-import "./utils.test.js";

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -168,5 +168,49 @@ describe('#transmit', () => {
         expect(xhrMock).toHaveBeenCalledTimes(1);
         expect(xhrMock.mock.calls[0][2]).toBe('GET')
         expect(byteSize(xhrMock.mock.calls[0][0])).toBeLessThan(8 * 1 << 10);
-    })
-})
+    });
+});
+
+describe('#initSystem', () => {
+    const systemConfig = { endpoint: 'example.com', apiKey: 'xxxxxxxxx' };
+
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    it('should write atlasId to localStorage after initSystem', () => {
+        const utils = new Utils(globalThis);
+        utils.initSystem(systemConfig);
+
+        expect(localStorage.getItem('atlasId')).not.toBeNull();
+        expect(localStorage.getItem('atlasId').length).toBeGreaterThan(4);
+    });
+
+    it('should read atlasId to localStorage when cookie is not set', () => {
+        const storeId = 'aabbcc.testlocalstorageatlasId';
+        localStorage.setItem('atlasId', storeId);
+        const utils = new Utils(globalThis);
+        utils.initSystem(systemConfig);
+        expect(localStorage.getItem('atlasId')).toBe(storeId);
+    });
+
+    it('should prefer cookie over localStorage when cookie is valid', () => {
+        const storeId = 'aabbcc.testlocalstorageatlasId';
+        localStorage.setItem('atlasId', storeId);
+        const cookieId = 'aabbcc.testcookieatlasId';
+        vi.spyOn(globalThis.document, 'cookie', 'get').mockReturnValue(`atlasId=${cookieId}; path=/;`); 
+
+        const utils = new Utils(globalThis);
+        utils.initSystem(systemConfig);
+        expect(localStorage.getItem('atlasId')).toBe(cookieId);
+        vi.restoreAllMocks();
+    });
+
+    it('should generate a new atlasId and save to localStorage when both cookie and localStorage are not set', () => {
+        const utils = new Utils(globalThis);
+        const expectedId = utils.uniqueId;
+        utils.initSystem(systemConfig);
+
+        expect(localStorage.getItem('atlasId')).toBe(expectedId);
+    });
+});


### PR DESCRIPTION
This PR adds the feature utilizing local storage to store atlas ID and use it as a fallback when cookie isn't available for some environments
Here are the commits for this change:
* f215ec5cf3703f693799ace0b95b3050208370c8
  * Add a method `setLS` in `utils.js`
  * set atlas ID to local storage when initialized
  * read local storage ID as fallback when atlas ID is not found in `document.cookie`
* 2320af5a4a345c60e0f5a7d00de9bca655f64971
  * add unit tests for local storage fallback 
* bd11795ade28030583c90e551337e956aaafc4d0
  * Remove unnecessary `index.test.js` (this file has no tests), which causes and error in vitest 