### PR TITLE
Remove non-existent message event handler variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -355,7 +355,7 @@ export default class AtlasTracking {
             targetWindow.removeEventListener('DOMContentLoaded', atlasDOMContentLoadedHandler);
         }
         if (options.trackThroughMessage && options.trackThroughMessage.enable) {
-            targetWindow.removeEventListener('message', atlasMessageHandler);
+            this.eventHandler.remove(eventHandlerKeys['message']);
         }
 
         options = {};


### PR DESCRIPTION
Follow-up of #156 
Unlike atlasDOMContentLoadedHandler, there is no variable named atlasMessageHandler. The message listener registered by trackThroughMessage()is stored in eventHandlerKeys["message"], so disableTracking() should remove that handler through the eventHandler helper.