### PR TITLE
Allow Atlas event messages to override user and context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -355,7 +355,7 @@ export default class AtlasTracking {
             targetWindow.removeEventListener('DOMContentLoaded', atlasDOMContentLoadedHandler);
         }
         if (options.trackThroughMessage && options.trackThroughMessage.enable) {
-            targetWindow.removeEventListener('message', atlasMessageHandler);
+            this.eventHandler.remove(eventHandlerKeys['message']);
         }
 
         options = {};

--- a/src/index.js
+++ b/src/index.js
@@ -751,11 +751,13 @@ export default class AtlasTracking {
                 // Nothing to do...
             }
             if(msg && msg.data && msg.data.isAtlasEvent){
+                const transmitContext = msg.data.contextOverride ? {...context, ...msg.data.contextOverride} : context;
+                const transmitUser = msg.data.userOverride ? {...user, ...msg.data.userOverride} : user;
                 this.utils.transmit(
                     msg.data.action,
                     msg.data.category,
-                    user,
-                    context,
+                    transmitUser,
+                    transmitContext,
                     attributes
                 );
             }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import AtlasTracking from '../src/index.js';
+
+describe('trackThroughMessage', () => {
+    it('merges override user/context into transmit payload', () => {
+        const atlas = new AtlasTracking();
+
+        atlas.config({
+            system: {
+                endpoint: 'example.test',
+                apiKey: 'dummy-api-key',
+                targetWindow: 'parent'
+            },
+            defaults: {},
+            product: {},
+            options: {
+                trackClick: {},
+                trackThroughMessage: {
+                    enable: true
+                }
+            }
+        });
+
+        const pageUser = {
+            user_id: 'base-user',
+        };
+        const pageContext = {
+            url: 'https://example.test/base',
+            page_title: 'base title',
+            page_name: 'article',
+            page_num: 1
+        };
+
+        atlas.initPage({
+            user: pageUser,
+            context: pageContext
+        });
+
+        const transmitSpy = vi.spyOn(atlas.utils, 'transmit').mockImplementation(() => {});
+        window.dispatchEvent(new MessageEvent('message', {
+            data: {
+                isAtlasEvent: true,
+                action: 'click',
+                category: 'button',
+                attributes: JSON.stringify({ cta: 'hero' }),
+                userOverride: { user_id: 'override-user' },
+                contextOverride: { url: 'https://example.test/override', page_num: 2 }
+            }
+        }));
+
+        expect(transmitSpy).toHaveBeenCalledTimes(1);
+        expect(transmitSpy).toHaveBeenCalledWith(
+            'click',
+            'button',
+            expect.objectContaining({
+                user_id: 'override-user',
+            }),
+            expect.objectContaining({
+                url: 'https://example.test/override',
+                page_name: 'article',
+                page_num: 2
+            }),
+            { cta: 'hero' }
+        );
+        expect(pageUser.user_id).toBe('base-user');
+        expect(pageContext.url).toBe('https://example.test/base');
+    });
+});


### PR DESCRIPTION
This PR  updates `trackThroughMessage` to accept `userOverride` and `contextOverride` from `postMessage` payloads and merge them into the existing `user`/`context` before calling `transmit`.
This enables per-event overrides while preserving page-level defaults initialized by `initPage`.
Also this adds a unit test in `test/index.test.js` to verify override precedence and retention of non-overridden base fields.