### PR TITLE
Change release.yml to create draft releases for immutable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release artifact
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: write
@@ -47,7 +47,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          draft: false
+          draft: true
           prerelease: false
 
       - name: Upload Release Asset


### PR DESCRIPTION

## Summary
This PR updates the GitHub Actions release workflow to create releases as **draft** to add additional assets under the immutable release setting.

## Change
- `draft: false` → `draft: true` in `release.yml`
