### PR TITLE
Introduce oxfmt formatter

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "tabWidth": 4,
+  "singleQuote": true,
+  "ignorePatterns": []
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,16 +18,8 @@ export default [
             },
         },
         rules: {
-            'newline-before-return': 'error',
             'no-console': 'off',
             'no-var': 'error',
-            indent: [
-                'error',
-                4,
-                {
-                    SwitchCase: 1,
-                },
-            ],
         },
     },
 ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build:npm": "rollup -c --bundleConfigAsCjs",
     "build:dist": "webpack -m -c ./webpack.common.js -c ./webpack.prd.js",
     "prepublishOnly": "pnpm run build:npm",
-    "eslint": "eslint --fix ./src --ext .js"
+    "eslint": "eslint --fix ./src --ext .js",
+    "format": "oxfmt src/ test/",
+    "format:check": "oxfmt --check src/ test/"
   },
   "author": "Nikkei Inc.",
   "license": "MIT",
@@ -22,6 +24,7 @@
     "eslint": "^10.0.0",
     "globals": "^17.0.0",
     "happy-dom": "^20.8.9",
+    "oxfmt": "^0.56.0",
     "rollup": "^4.59.0",
     "vitest": "^4.0.1",
     "webpack": "^5.104.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       happy-dom:
         specifier: ^20.8.9
         version: 20.8.9
+      oxfmt:
+        specifier: ^0.56.0
+        version: 0.56.0
       rollup:
         specifier: ^4.59.0
         version: 4.59.0
@@ -798,6 +801,128 @@ packages:
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
+  '@oxfmt/binding-android-arm-eabi@0.56.0':
+    resolution: {integrity: sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.56.0':
+    resolution: {integrity: sha512-HYJFnd+PkDwf6S9ZPGzXXtjNqvRWFnnhdbWaouh4mi/SxU8wmDuzlMn3xo/wDTGnr4Q1VA7ZzOaE/D4biW0W6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.56.0':
+    resolution: {integrity: sha512-sftR/bEOr+t1gs+evwsHi/Xbq2FAPA2uU3VMr8n6ZU9PoK/IMSfnfu7+OEe/uy1+knhrFl4Wvy7Vkm3uo9mJ7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.56.0':
+    resolution: {integrity: sha512-z66SdjLqa3MUPKvTp3Mbb5nSjKSbnYxJGeB+Wx987s8T5hPcIRiBMfnJ6zcPgYtQn3x5xjvdzNVkXrSeYH6ZFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.56.0':
+    resolution: {integrity: sha512-t2tkrV1vtZyaItSQ71dTi2ZVKZEI39b/LqLT12V5KMfIeXK6N32TUC1jhOXKVQmhECq9j2ZXMQV3JeT1kh9Vmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.56.0':
+    resolution: {integrity: sha512-+gCy+Tp3RHeXQ9y/QrS76lXIpZkbziTyp6hIgjB2MssCwfMph3vG/GEfkhO34Rai1vhYIaUkvv8UT1BcDorJPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.56.0':
+    resolution: {integrity: sha512-0kKkVvQ2I+FJ2sxQyUu1zJ0yWP5kcWse/yVFnGQSFCXMwSSkfEaUGu0dW774O7nyy3jrcBGap7OSc8dZmU/CdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.56.0':
+    resolution: {integrity: sha512-npkA2siMbyWRh+wEhi1aTAx4RirukGcGNt8V4Ch86pG+xU9aurqS1MZOnKYMu03ISwat3rB6zkQx51SsB9obNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.56.0':
+    resolution: {integrity: sha512-UekqOjGkV4/MkqreCV9SPIB2jlR3/HbXrmhV1rVXJZ9wfDXMyCMriLtq3tHqLY4PkbVWNtfcm1kMojJ26KLSJw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.56.0':
+    resolution: {integrity: sha512-XSzveSpeZMD5XJpew5lRFVtNnT04xd3rJxENXmk7wkZzN9oWzv2aFJyoNDhOtoz69BYaS/fg4SYl+CfEZRpB0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.56.0':
+    resolution: {integrity: sha512-EkQ0nJa7k7HDDIVuPF7WY+k4k+bzdclLYtyIXNt7/OqVghfNiMym6YGppFBgx1XRIHW6QylxBz5OogumPjPJbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.56.0':
+    resolution: {integrity: sha512-dyjAGW8jKRge0ik6U/dgvQG0nVpA3iBlRskQTz5qJLvQWIrySxX5jpqzPetLBNIIZ231KA82fDdi1nLTk8ENCw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.56.0':
+    resolution: {integrity: sha512-60ZGH3LtfqlW8X6vcLdSFY4lvCQYINurttYBKaALnHCDVAUCYJ1LsUgS6p1XOzVlzEDx3yNUZvDF1Lvt59zoZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.56.0':
+    resolution: {integrity: sha512-u1suj1tgJHK4ZqB7buCtdbNef2n8+d0lXTPJwLHNmtyK6p+DTpsaoDvmqhQrA56fgKYv4LuRxNtL8YooebKOew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.56.0':
+    resolution: {integrity: sha512-aYGLvlQHt80y+qKEtfJY/Nm27G0125Lv+qyh9SJ4Cjc6lXnXjD+ndfhqQnbV24POpMi7rNRi0jvx/0d70FRpCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.56.0':
+    resolution: {integrity: sha512-H/re/gO+7ysVc+kywHNuzY3C33EN9sQcZhg0kp1ZwOZl7y998ZE5mhnBiuGR/nYI0pqLL5xQfrHVUOJ/cIJsCA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.56.0':
+    resolution: {integrity: sha512-6qLNXfXmtAs8jXDvYMkxk6Wec5SUJoew+ZX1uOZmqaR7ks0EJFbAohuOCELDyJMWyVlxotVG8Xf8m74Bfq0O2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.56.0':
+    resolution: {integrity: sha512-UXEXuKphAe15bsob4AswNMArCw38XSmUIs3wk1s6e6MX9OWGW/IRWU95s1hZDiVg09STy1jHgyN2qkqbu1FT0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.56.0':
+    resolution: {integrity: sha512-HPyNDjky+NIOuaMvHZflR+kst3YWdUOH2JUQYkf99grqZ5mEBTQM6h9iGy501Z8Xt5xMScrwHOuVCOlqDrktRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -1526,6 +1651,19 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  oxfmt@0.56.0:
+    resolution: {integrity: sha512-9Dv0wV3zKiyvhjD7bRKaInKmHQ1sPx3RGOjQkGFJbbdQ16576yf8qhMSO9Q9cvHcs+1NpBsRTkuDDYFFPTJ6gw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -1724,6 +1862,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
@@ -2730,6 +2872,63 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
+  '@oxfmt/binding-android-arm-eabi@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.56.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.56.0':
+    optional: true
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -3402,6 +3601,30 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  oxfmt@0.56.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.56.0
+      '@oxfmt/binding-android-arm64': 0.56.0
+      '@oxfmt/binding-darwin-arm64': 0.56.0
+      '@oxfmt/binding-darwin-x64': 0.56.0
+      '@oxfmt/binding-freebsd-x64': 0.56.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.56.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.56.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.56.0
+      '@oxfmt/binding-linux-arm64-musl': 0.56.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.56.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.56.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.56.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.56.0
+      '@oxfmt/binding-linux-x64-gnu': 0.56.0
+      '@oxfmt/binding-linux-x64-musl': 0.56.0
+      '@oxfmt/binding-openharmony-arm64': 0.56.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.56.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.56.0
+      '@oxfmt/binding-win32-x64-msvc': 0.56.0
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -3586,7 +3809,7 @@ snapshots:
   terser@5.46.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -3598,6 +3821,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.0.3: {}
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ let eventHandlerKeys = {
     click: null,
     viewability: {},
     media: {},
-    form: {}
+    form: {},
 };
 
 let isInitialized = false;
@@ -34,9 +34,7 @@ let pageLoadedAt, prevActionOccurredAt;
 pageLoadedAt = prevActionOccurredAt = Date.now();
 
 export default class AtlasTracking {
-    constructor() {
-
-    }
+    constructor() {}
 
     /**
      * get current url's query value associated with argument.
@@ -55,7 +53,6 @@ export default class AtlasTracking {
     getCookieValue(k) {
         return this.utils.getC(k) || '';
     }
-
 
     /**
      * get current localStorage value associated with argument.
@@ -97,13 +94,22 @@ export default class AtlasTracking {
      * @param  {Object} obj configuration object.
      */
     config(obj) {
-
         system = obj.system !== void 0 ? obj.system : {};
         targetWindow = system.targetWindow ? window[system.targetWindow] : window['parent'];
-        defaults.url = obj.defaults.pageUrl !== void 0 ? obj.defaults.pageUrl : targetWindow.document.location.href;
-        defaults.referrer = obj.defaults.pageReferrer !== void 0 ? obj.defaults.pageReferrer : targetWindow.document.referrer;
-        defaults.page_title = obj.defaults.pageTitle !== void 0 ? obj.defaults.pageTitle : targetWindow.document.title;
-        defaults.product_family = obj.product.productFamily !== void 0 ? obj.product.productFamily : null;
+        defaults.url =
+            obj.defaults.pageUrl !== void 0
+                ? obj.defaults.pageUrl
+                : targetWindow.document.location.href;
+        defaults.referrer =
+            obj.defaults.pageReferrer !== void 0
+                ? obj.defaults.pageReferrer
+                : targetWindow.document.referrer;
+        defaults.page_title =
+            obj.defaults.pageTitle !== void 0
+                ? obj.defaults.pageTitle
+                : targetWindow.document.title;
+        defaults.product_family =
+            obj.product.productFamily !== void 0 ? obj.product.productFamily : null;
         defaults.product = obj.product.productName !== void 0 ? obj.product.productName : null;
 
         this.utils = new Utils(targetWindow);
@@ -123,7 +129,11 @@ export default class AtlasTracking {
             visibilityEvent = targetWindow.document.createEvent('CustomEvent');
             visibilityEvent.initCustomEvent(visibilityEventName, false, false, {});
         }
-        let requestAnimationFrame = targetWindow.requestAnimationFrame || targetWindow.mozRequestAnimationFrame || targetWindow.webkitRequestAnimationFrame || targetWindow.msRequestAnimationFrame;
+        let requestAnimationFrame =
+            targetWindow.requestAnimationFrame ||
+            targetWindow.mozRequestAnimationFrame ||
+            targetWindow.webkitRequestAnimationFrame ||
+            targetWindow.msRequestAnimationFrame;
 
         if (requestAnimationFrame) {
             targetWindow.requestAnimationFrame = requestAnimationFrame;
@@ -136,7 +146,7 @@ export default class AtlasTracking {
                     callback(currTime + timeToCall);
                 }, timeToCall);
                 lastTime = currTime + timeToCall;
-                
+
                 return id;
             };
         }
@@ -212,11 +222,15 @@ export default class AtlasTracking {
      * re-attach event listeners to DOMs.
      */
     initEventListeners() {
-        if ((options.trackClick && options.trackClick.enable) || (options.trackLink && options.trackLink.enable) || (options.trackDownload && options.trackDownload.enable)) {
+        if (
+            (options.trackClick && options.trackClick.enable) ||
+            (options.trackLink && options.trackLink.enable) ||
+            (options.trackDownload && options.trackDownload.enable)
+        ) {
             this.delegateClickEvents({
-                'trackClick': options.trackClick,
-                'trackLink': options.trackLink,
-                'trackDownload': options.trackDownload
+                trackClick: options.trackClick,
+                trackLink: options.trackLink,
+                trackDownload: options.trackDownload,
             });
         }
         if (options.trackUnload && options.trackUnload.enable) {
@@ -226,10 +240,17 @@ export default class AtlasTracking {
             this.trackScroll(options.trackScroll.granularity, options.trackScroll.threshold);
         }
         if (options.trackInfinityScroll && options.trackInfinityScroll.enable) {
-            this.trackInfinityScroll(options.trackInfinityScroll.step, options.trackInfinityScroll.threshold);
+            this.trackInfinityScroll(
+                options.trackInfinityScroll.step,
+                options.trackInfinityScroll.threshold,
+            );
         }
         if (options.trackRead && options.trackRead.enable) {
-            this.trackRead(options.trackRead.target, options.trackRead.granularity, options.trackRead.milestones);
+            this.trackRead(
+                options.trackRead.target,
+                options.trackRead.granularity,
+                options.trackRead.milestones,
+            );
         }
         if (options.trackViewability && options.trackViewability.enable) {
             this.trackViewability(options.trackViewability.targets);
@@ -261,9 +282,9 @@ export default class AtlasTracking {
         const paramUser = obj.user;
         const paramContext = obj.context;
 
-        if(isInitialized){
+        if (isInitialized) {
             pageLoadedAt = prevActionOccurredAt = Date.now();
-        }else{
+        } else {
             isInitialized = true;
         }
 
@@ -275,9 +296,11 @@ export default class AtlasTracking {
         if (paramContext !== void 0) {
             context = paramContext;
             context.root_id = this.utils.getUniqueId();
-            context.page_title = paramContext.page_title !== void 0 ? paramContext.page_title : defaults.page_title;
+            context.page_title =
+                paramContext.page_title !== void 0 ? paramContext.page_title : defaults.page_title;
             context.url = paramContext.url !== void 0 ? paramContext.url : defaults.url;
-            context.referrer = paramContext.referrer !== void 0 ? paramContext.referrer : defaults.referrer;
+            context.referrer =
+                paramContext.referrer !== void 0 ? paramContext.referrer : defaults.referrer;
             context.product_family = paramContext.product_family || defaults.product_family;
             context.product = paramContext.product || defaults.product;
             context.page_num = paramContext.page_num || 1;
@@ -285,23 +308,23 @@ export default class AtlasTracking {
             context.custom_object = paramContext.custom_object || {};
             context.funnel = paramContext.funnel || {};
 
-            if(options.trackClick.logLastClick){
+            if (options.trackClick.logLastClick) {
                 const ttl = options.trackClick.lastClickTtl || 5;
                 let atlasLastClickJson = '';
                 let atlasLastClickObj = {};
 
-                try{
+                try {
                     atlasLastClickJson = sessionStorage.getItem(lastClickStorageKey);
                     atlasLastClickObj = JSON.parse(atlasLastClickJson) || {};
                     sessionStorage.removeItem(lastClickStorageKey);
-                }catch(e){
+                } catch (e) {
                     // Nothing to do
                 }
 
-                if((Date.now() - atlasLastClickObj.ts) <= (ttl * 1000)){
+                if (Date.now() - atlasLastClickObj.ts <= ttl * 1000) {
                     context.last_click = atlasLastClickObj.attr;
                 }
-            }            
+            }
         }
 
         if (options.trackNavigation && options.trackNavigation.enable) {
@@ -320,7 +343,11 @@ export default class AtlasTracking {
      * remove tracking options and handlers
      */
     disableTracking() {
-        if ((options.trackClick && options.trackClick.enable) || (options.trackLink && options.trackLink.enable) || (options.trackDownload && options.trackDownload.enable)) {
+        if (
+            (options.trackClick && options.trackClick.enable) ||
+            (options.trackLink && options.trackLink.enable) ||
+            (options.trackDownload && options.trackDownload.enable)
+        ) {
             this.eventHandler.remove(eventHandlerKeys['click']);
         }
         if (options.trackUnload && options.trackUnload.enable) {
@@ -379,17 +406,17 @@ export default class AtlasTracking {
         const now = Date.now();
         context.events = events || null;
         this.utils.transmit(action, category, user, context, {
-            'action': {
-                'location': obj.location || undefined,
-                'destination': obj.destination || undefined,
-                'dataset': obj.dataset || undefined,
-                'name': obj.action_name || undefined,
-                'elapsed_since_page_load': (now - pageLoadedAt) / 1000,
-                'elapsed_since_prev_action': (now - prevActionOccurredAt) / 1000,
-                'content_id': obj.content_id || undefined,
-                'content_name': obj.content_name || undefined,
-                'custom_vars': obj.custom_vars || {}
-            }
+            action: {
+                location: obj.location || undefined,
+                destination: obj.destination || undefined,
+                dataset: obj.dataset || undefined,
+                name: obj.action_name || undefined,
+                elapsed_since_page_load: (now - pageLoadedAt) / 1000,
+                elapsed_since_prev_action: (now - prevActionOccurredAt) / 1000,
+                content_id: obj.content_id || undefined,
+                content_name: obj.content_name || undefined,
+                custom_vars: obj.custom_vars || {},
+            },
         });
         context.events = null;
         prevActionOccurredAt = now;
@@ -400,84 +427,122 @@ export default class AtlasTracking {
      */
     delegateClickEvents(obj) {
         this.eventHandler.remove(eventHandlerKeys['click']);
-        eventHandlerKeys['click'] = this.eventHandler.add(targetWindow.document.body, 'click', (ev) => {
-            const trackClickConfig = obj.trackClick;
-            const targetAttribute = trackClickConfig && trackClickConfig.targetAttribute ? trackClickConfig.targetAttribute : false;
-            const targetElement = this.utils.qsM('a, button, [role="button"]', ev.target, targetAttribute);
+        eventHandlerKeys['click'] = this.eventHandler.add(
+            targetWindow.document.body,
+            'click',
+            (ev) => {
+                const trackClickConfig = obj.trackClick;
+                const targetAttribute =
+                    trackClickConfig && trackClickConfig.targetAttribute
+                        ? trackClickConfig.targetAttribute
+                        : false;
+                const targetElement = this.utils.qsM(
+                    'a, button, [role="button"]',
+                    ev.target,
+                    targetAttribute,
+                );
 
-            if(targetElement && targetElement.element){
+                if (targetElement && targetElement.element) {
+                    let elm = targetElement.element;
+                    let ext = (elm.pathname || '').match(/.+\/.+?\.([a-z]+([?#;].*)?$)/);
+                    let attr = {
+                        destination: elm.href || undefined,
+                        dataset: elm.dataset || undefined,
+                        target: elm.target || undefined,
+                        media: elm.media || undefined,
+                        type: elm.type || undefined,
+                        tag: elm.tagName.toLowerCase(),
+                        id: elm.id || undefined,
+                        class: elm.className || undefined,
+                        location: targetElement.pathDom || undefined,
+                        elapsed_since_page_load: (Date.now() - pageLoadedAt) / 1000,
+                    };
 
-                let elm = targetElement.element;
-                let ext = (elm.pathname || '').match(/.+\/.+?\.([a-z]+([?#;].*)?$)/);
-                let attr = {
-                    'destination': elm.href || undefined,
-                    'dataset': elm.dataset || undefined,
-                    'target': elm.target || undefined,
-                    'media': elm.media || undefined,
-                    'type': elm.type || undefined,
-                    'tag': elm.tagName.toLowerCase(),
-                    'id': elm.id || undefined,
-                    'class': elm.className || undefined,
-                    'location': targetElement.pathDom || undefined,
-                    'elapsed_since_page_load': ((Date.now()) - pageLoadedAt) / 1000
-                };
-
-                // Outbound
-                if (obj.trackLink && obj.trackLink.enable && elm.hostname && targetWindow.location.hostname !== elm.hostname && obj.trackLink.internalDomains.indexOf(elm.hostname) < 0) {
-                    attr['name'] = this.utils.getAttr(obj.trackLink.targetAttribute, elm);
-                    attr['text'] = !obj.trackLink.disableText ? (elm.innerText || elm.value || '').substr(0,63) : undefined;
-                    this.utils.transmit('open', 'outbound_link', user, context, {
-                        'link': attr
-                    });
-                }
-
-                // Download
-                if (obj.trackDownload && obj.trackDownload.enable && elm.hostname && ext && obj.trackDownload.fileExtensions.indexOf(ext[1]) >= 0) {
-                    attr['name'] = this.utils.getAttr(obj.trackDownload.targetAttribute, elm);
-                    attr['text'] = !obj.trackDownload.disableText ? (elm.innerText || elm.value || '').substr(0,63) : undefined;
-                    this.utils.transmit('download', 'file', user, context, {
-                        'download': attr
-                    });
-                }
-
-                // Click
-                if (trackClickConfig && trackClickConfig.enable && targetElement) {
-
-                    if(
-                        !targetAttribute
-                        || trackClickConfig.logAllClicks
-                        || (targetAttribute && elm.attributes[targetAttribute])
-                    ){
-                        attr['name'] = targetAttribute ? this.utils.getAttr(trackClickConfig.targetAttribute, elm) : undefined;
-                        attr['text'] = !trackClickConfig.disableText ? (elm.innerText || elm.value || '').substr(0,63) : undefined;
-
-                        if(targetElement.pathTrackable.length > 0){
-                            attr['location'] = targetElement.pathTrackable;
-                        }
-
-                        // Last Click
-                        if(trackClickConfig.logLastClick){
-                            try{
-                                sessionStorage.setItem(lastClickStorageKey, JSON.stringify({
-                                    ts: Date.now(),
-                                    attr: attr
-                                }));
-                            }catch(e){
-                                // Nothing to do
-                            }
-                        }
-
-                        // If useLastClickOnly is false
-                        if(!trackClickConfig.useLastClickOnly){
-                            this.utils.transmit('click', targetElement.category, user, context, {
-                                'action': attr
-                            });
-                        }
+                    // Outbound
+                    if (
+                        obj.trackLink &&
+                        obj.trackLink.enable &&
+                        elm.hostname &&
+                        targetWindow.location.hostname !== elm.hostname &&
+                        obj.trackLink.internalDomains.indexOf(elm.hostname) < 0
+                    ) {
+                        attr['name'] = this.utils.getAttr(obj.trackLink.targetAttribute, elm);
+                        attr['text'] = !obj.trackLink.disableText
+                            ? (elm.innerText || elm.value || '').substr(0, 63)
+                            : undefined;
+                        this.utils.transmit('open', 'outbound_link', user, context, {
+                            link: attr,
+                        });
                     }
 
+                    // Download
+                    if (
+                        obj.trackDownload &&
+                        obj.trackDownload.enable &&
+                        elm.hostname &&
+                        ext &&
+                        obj.trackDownload.fileExtensions.indexOf(ext[1]) >= 0
+                    ) {
+                        attr['name'] = this.utils.getAttr(obj.trackDownload.targetAttribute, elm);
+                        attr['text'] = !obj.trackDownload.disableText
+                            ? (elm.innerText || elm.value || '').substr(0, 63)
+                            : undefined;
+                        this.utils.transmit('download', 'file', user, context, {
+                            download: attr,
+                        });
+                    }
+
+                    // Click
+                    if (trackClickConfig && trackClickConfig.enable && targetElement) {
+                        if (
+                            !targetAttribute ||
+                            trackClickConfig.logAllClicks ||
+                            (targetAttribute && elm.attributes[targetAttribute])
+                        ) {
+                            attr['name'] = targetAttribute
+                                ? this.utils.getAttr(trackClickConfig.targetAttribute, elm)
+                                : undefined;
+                            attr['text'] = !trackClickConfig.disableText
+                                ? (elm.innerText || elm.value || '').substr(0, 63)
+                                : undefined;
+
+                            if (targetElement.pathTrackable.length > 0) {
+                                attr['location'] = targetElement.pathTrackable;
+                            }
+
+                            // Last Click
+                            if (trackClickConfig.logLastClick) {
+                                try {
+                                    sessionStorage.setItem(
+                                        lastClickStorageKey,
+                                        JSON.stringify({
+                                            ts: Date.now(),
+                                            attr: attr,
+                                        }),
+                                    );
+                                } catch (e) {
+                                    // Nothing to do
+                                }
+                            }
+
+                            // If useLastClickOnly is false
+                            if (!trackClickConfig.useLastClickOnly) {
+                                this.utils.transmit(
+                                    'click',
+                                    targetElement.category,
+                                    user,
+                                    context,
+                                    {
+                                        action: attr,
+                                    },
+                                );
+                            }
+                        }
+                    }
                 }
-            }
-        }, false);
+            },
+            false,
+        );
     }
 
     /**
@@ -485,14 +550,19 @@ export default class AtlasTracking {
      */
     setEventToUnload() {
         this.eventHandler.remove(eventHandlerKeys['unload']);
-        eventHandlerKeys['unload'] = this.eventHandler.add(targetWindow, unloadEvent, () => {
-            this.utils.transmit('unload', 'page', user, context, {
-                'action': {
-                    'name': 'leave_from_page',
-                    'elapsed_since_page_load': ((Date.now()) - pageLoadedAt) / 1000
-                }
-            });
-        }, false);
+        eventHandlerKeys['unload'] = this.eventHandler.add(
+            targetWindow,
+            unloadEvent,
+            () => {
+                this.utils.transmit('unload', 'page', user, context, {
+                    action: {
+                        name: 'leave_from_page',
+                        elapsed_since_page_load: (Date.now() - pageLoadedAt) / 1000,
+                    },
+                });
+            },
+            false,
+        );
     }
 
     /**
@@ -508,30 +578,38 @@ export default class AtlasTracking {
         let cvr = 0; //currentViewRate
         let pvr = 0; //prevViewRate
         this.eventHandler.remove(eventHandlerKeys['scroll']);
-        eventHandlerKeys['scroll'] = this.eventHandler.add(targetWindow, visibilityEventName, () => {
-            r = this.utils.getV(null);
-            if (r.detail.documentIsVisible !== 'hidden' && r.detail.documentIsVisible !== 'prerender') {
-                now = Date.now();
-                cvr = Math.round(r.detail.documentScrollRate * steps) * each;
-                if (cvr > pvr && cvr >= 0 && cvr <= 100) {
-                    setTimeout(() => {
-                        if (cvr > pvr) {
-                            this.utils.transmit('scroll', 'page', user, context, {
-                                'scroll_depth': {
-                                    'page_height': r.detail.documentHeight,
-                                    'viewed_until': r.detail.documentScrollUntil,
-                                    'viewed_percent': cvr,
-                                    'elapsed_since_page_load': (now - pageLoadedAt) / 1000,
-                                    'elapsed_since_prev_action': (now - prev) / 1000
-                                }
-                            });
-                            pvr = cvr;
-                        }
-                        prev = now;
-                    }, limit);
+        eventHandlerKeys['scroll'] = this.eventHandler.add(
+            targetWindow,
+            visibilityEventName,
+            () => {
+                r = this.utils.getV(null);
+                if (
+                    r.detail.documentIsVisible !== 'hidden' &&
+                    r.detail.documentIsVisible !== 'prerender'
+                ) {
+                    now = Date.now();
+                    cvr = Math.round(r.detail.documentScrollRate * steps) * each;
+                    if (cvr > pvr && cvr >= 0 && cvr <= 100) {
+                        setTimeout(() => {
+                            if (cvr > pvr) {
+                                this.utils.transmit('scroll', 'page', user, context, {
+                                    scroll_depth: {
+                                        page_height: r.detail.documentHeight,
+                                        viewed_until: r.detail.documentScrollUntil,
+                                        viewed_percent: cvr,
+                                        elapsed_since_page_load: (now - pageLoadedAt) / 1000,
+                                        elapsed_since_prev_action: (now - prev) / 1000,
+                                    },
+                                });
+                                pvr = cvr;
+                            }
+                            prev = now;
+                        }, limit);
+                    }
                 }
-            }
-        }, false);
+            },
+            false,
+        );
     }
 
     /**
@@ -545,30 +623,38 @@ export default class AtlasTracking {
         let cvp = 0; //currentViewRate
         let pvp = 0; //prevViewRate
         this.eventHandler.remove(eventHandlerKeys['infinityScroll']);
-        eventHandlerKeys['infinityScroll'] = this.eventHandler.add(targetWindow, visibilityEventName, () => {
-            r = this.utils.getV(null);
-            if (r.detail.documentIsVisible !== 'hidden' && r.detail.documentIsVisible !== 'prerender') {
-                now = Date.now();
-                cvp = r.detail.documentScrollUntil;
-                if (cvp > pvp && cvp >= pvp && cvp >= step) {
-                    setTimeout(() => {
-                        if (cvp > pvp) {
-                            this.utils.transmit('infinity_scroll', 'page', user, context, {
-                                'scroll_depth': {
-                                    'page_height': r.detail.documentHeight,
-                                    'viewed_until': cvp,
-                                    'viewed_percent': r.detail.documentScrollRate,
-                                    'elapsed_since_page_load': (now - pageLoadedAt) / 1000,
-                                    'elapsed_since_prev_action': (now - prev) / 1000
-                                }
-                            });
-                            pvp = cvp + step;
-                        }
-                        prev = now;
-                    }, limit);
+        eventHandlerKeys['infinityScroll'] = this.eventHandler.add(
+            targetWindow,
+            visibilityEventName,
+            () => {
+                r = this.utils.getV(null);
+                if (
+                    r.detail.documentIsVisible !== 'hidden' &&
+                    r.detail.documentIsVisible !== 'prerender'
+                ) {
+                    now = Date.now();
+                    cvp = r.detail.documentScrollUntil;
+                    if (cvp > pvp && cvp >= pvp && cvp >= step) {
+                        setTimeout(() => {
+                            if (cvp > pvp) {
+                                this.utils.transmit('infinity_scroll', 'page', user, context, {
+                                    scroll_depth: {
+                                        page_height: r.detail.documentHeight,
+                                        viewed_until: cvp,
+                                        viewed_percent: r.detail.documentScrollRate,
+                                        elapsed_since_page_load: (now - pageLoadedAt) / 1000,
+                                        elapsed_since_prev_action: (now - prev) / 1000,
+                                    },
+                                });
+                                pvp = cvp + step;
+                            }
+                            prev = now;
+                        }, limit);
+                    }
                 }
-            }
-        }, false);
+            },
+            false,
+        );
     }
 
     /**
@@ -588,59 +674,68 @@ export default class AtlasTracking {
         let cvr = 0; //currentViewRate
         let pvr = 0; //prevViewRate
         this.eventHandler.remove(eventHandlerKeys['read']);
-        eventHandlerKeys['read'] = this.eventHandler.add(targetWindow, visibilityEventName, () => {
-            r = this.utils.getV(target);
-            if (r.detail.documentIsVisible !== 'hidden' && r.detail.documentIsVisible !== 'prerender' && r.status.isInView) {
-                now = Date.now();
-                if (now - prevVisible >= 1000) {
+        eventHandlerKeys['read'] = this.eventHandler.add(
+            targetWindow,
+            visibilityEventName,
+            () => {
+                r = this.utils.getV(target);
+                if (
+                    r.detail.documentIsVisible !== 'hidden' &&
+                    r.detail.documentIsVisible !== 'prerender' &&
+                    r.status.isInView
+                ) {
+                    now = Date.now();
+                    if (now - prevVisible >= 1000) {
+                        prevVisible = now;
+                    }
+                    eiv = eiv + (now - prevVisible);
                     prevVisible = now;
-                }
-                eiv = eiv + (now - prevVisible);
-                prevVisible = now;
 
-                // Milestone based
-                if(milestones.length > 0 && milestones[0] <= (eiv / 1000)){
-                    this.utils.transmit('read', 'article', user, context, {
-                        'read': {
-                            'mode': 'time',
-                            'milestone': milestones[0],
-                            'page_height': r.detail.documentHeight,
-                            'element_height': r.detail.targetHeight,
-                            'viewed_from': r.detail.targetVisibleTop,
-                            'viewed_until': r.detail.targetVisibleBottom,
-                            'viewed_percent': cvr,
-                            'elapsed_since_page_load': (now - pageLoadedAt) / 1000,
-                            'elapsed_since_prev_action': (now - prev) / 1000
-                        }
-                    });
-                    prev = now;
-                    milestones.shift();
-                }
-
-                // Scroll based
-                cvr = Math.round(r.detail.targetScrollRate * steps) * each;
-                if (cvr > pvr && cvr >= 0 && cvr <= 100) {
-                    setTimeout(() => {
-                        if (cvr > pvr) {
-                            this.utils.transmit('read', 'article', user, context, {
-                                'read': {
-                                    'mode': 'scroll',
-                                    'page_height': r.detail.documentHeight,
-                                    'element_height': r.detail.targetHeight,
-                                    'viewed_from': r.detail.targetVisibleTop,
-                                    'viewed_until': r.detail.targetVisibleBottom,
-                                    'viewed_percent': cvr,
-                                    'elapsed_since_page_load': (now - pageLoadedAt) / 1000,
-                                    'elapsed_since_prev_action': (now - prev) / 1000
-                                }
-                            });
-                            pvr = cvr;
-                        }
+                    // Milestone based
+                    if (milestones.length > 0 && milestones[0] <= eiv / 1000) {
+                        this.utils.transmit('read', 'article', user, context, {
+                            read: {
+                                mode: 'time',
+                                milestone: milestones[0],
+                                page_height: r.detail.documentHeight,
+                                element_height: r.detail.targetHeight,
+                                viewed_from: r.detail.targetVisibleTop,
+                                viewed_until: r.detail.targetVisibleBottom,
+                                viewed_percent: cvr,
+                                elapsed_since_page_load: (now - pageLoadedAt) / 1000,
+                                elapsed_since_prev_action: (now - prev) / 1000,
+                            },
+                        });
                         prev = now;
-                    }, 1000);
+                        milestones.shift();
+                    }
+
+                    // Scroll based
+                    cvr = Math.round(r.detail.targetScrollRate * steps) * each;
+                    if (cvr > pvr && cvr >= 0 && cvr <= 100) {
+                        setTimeout(() => {
+                            if (cvr > pvr) {
+                                this.utils.transmit('read', 'article', user, context, {
+                                    read: {
+                                        mode: 'scroll',
+                                        page_height: r.detail.documentHeight,
+                                        element_height: r.detail.targetHeight,
+                                        viewed_from: r.detail.targetVisibleTop,
+                                        viewed_until: r.detail.targetVisibleBottom,
+                                        viewed_percent: cvr,
+                                        elapsed_since_page_load: (now - pageLoadedAt) / 1000,
+                                        elapsed_since_prev_action: (now - prev) / 1000,
+                                    },
+                                });
+                                pvr = cvr;
+                            }
+                            prev = now;
+                        }, 1000);
+                    }
                 }
-            }
-        }, false);
+            },
+            false,
+        );
     }
 
     /**
@@ -651,32 +746,50 @@ export default class AtlasTracking {
         let r = {}; //results
         let f = {}; //flags
         this.eventHandler.remove(eventHandlerKeys['viewability']);
-        eventHandlerKeys['viewability'] = this.eventHandler.add(targetWindow, visibilityEventName, () => {
-            for (let i = 0; i < targets.length; i++) {
-                if (targets[i]) {
-                    r[i] = this.utils.getV(targets[i]);
-                    if (r[i].status.isInView === true && r[i].detail.documentIsVisible !== 'hidden' && r[i].detail.documentIsVisible !== 'prerender' && r[i].detail.targetViewableRate >= 0.5 && !f[i]) {
-                        setTimeout(() => {
-                            if (r[i].detail.targetViewableRate >= 0.5 && !f[i]) {
-                                now = Date.now();
-                                f[i] = true;
-                                this.utils.transmit('viewable_impression', 'ad', user, context, {
-                                    'viewability': {
-                                        'page_height': r[i].detail.documentHeight,
-                                        'element_order_in_target': i,
-                                        'element_tag': targets[i].tagName,
-                                        'element_class': targets[i].className,
-                                        'element_id': targets[i].id,
-                                        'element_height': r[i].detail.targetHeight,
-                                        'elapsed_since_page_load': (now - pageLoadedAt) / 1000
-                                    }
-                                });
-                            }
-                        }, 1000);
+        eventHandlerKeys['viewability'] = this.eventHandler.add(
+            targetWindow,
+            visibilityEventName,
+            () => {
+                for (let i = 0; i < targets.length; i++) {
+                    if (targets[i]) {
+                        r[i] = this.utils.getV(targets[i]);
+                        if (
+                            r[i].status.isInView === true &&
+                            r[i].detail.documentIsVisible !== 'hidden' &&
+                            r[i].detail.documentIsVisible !== 'prerender' &&
+                            r[i].detail.targetViewableRate >= 0.5 &&
+                            !f[i]
+                        ) {
+                            setTimeout(() => {
+                                if (r[i].detail.targetViewableRate >= 0.5 && !f[i]) {
+                                    now = Date.now();
+                                    f[i] = true;
+                                    this.utils.transmit(
+                                        'viewable_impression',
+                                        'ad',
+                                        user,
+                                        context,
+                                        {
+                                            viewability: {
+                                                page_height: r[i].detail.documentHeight,
+                                                element_order_in_target: i,
+                                                element_tag: targets[i].tagName,
+                                                element_class: targets[i].className,
+                                                element_id: targets[i].id,
+                                                element_height: r[i].detail.targetHeight,
+                                                elapsed_since_page_load:
+                                                    (now - pageLoadedAt) / 1000,
+                                            },
+                                        },
+                                    );
+                                }
+                            }, 1000);
+                        }
                     }
                 }
-            }
-        }, false);
+            },
+            false,
+        );
     }
 
     /**
@@ -687,34 +800,44 @@ export default class AtlasTracking {
         let f = {}; //flags
         for (let i = 0; i < targetEvents.length; i++) {
             this.eventHandler.remove(eventHandlerKeys['media'][targetEvents[i]]);
-            eventHandlerKeys['media'][targetEvents[i]] = this.eventHandler.add(targetWindow.document.body, targetEvents[i], (ev) => {
-                if (this.utils.qsM(selector, ev.target)) {
-                    const details = this.utils.getM(ev.target);
-                    this.utils.transmit(targetEvents[i], details.tag, user, context, {
-                        'media': details
-                    });
-                }
-            }, {capture: true});
+            eventHandlerKeys['media'][targetEvents[i]] = this.eventHandler.add(
+                targetWindow.document.body,
+                targetEvents[i],
+                (ev) => {
+                    if (this.utils.qsM(selector, ev.target)) {
+                        const details = this.utils.getM(ev.target);
+                        this.utils.transmit(targetEvents[i], details.tag, user, context, {
+                            media: details,
+                        });
+                    }
+                },
+                { capture: true },
+            );
         }
 
         this.eventHandler.remove(eventHandlerKeys['media']['timeupdate']);
-        eventHandlerKeys['media']['timeupdate'] = this.eventHandler.add(targetWindow.document, 'timeupdate', (ev) => {
-            if (this.utils.qsM(selector, ev.target)) {
-                const details = this.utils.getM(ev.target);
-                const index = details.tag + '-' + details.id + '-' + details.src;
-                if (f[index]) {
-                    return false;
-                }
-                f[index] = setTimeout(() => {
-                    if (ev.target.paused !== true && ev.target.ended !== true) {
-                        this.utils.transmit('playing', details.tag, user, context, {
-                            'media': details
-                        });
+        eventHandlerKeys['media']['timeupdate'] = this.eventHandler.add(
+            targetWindow.document,
+            'timeupdate',
+            (ev) => {
+                if (this.utils.qsM(selector, ev.target)) {
+                    const details = this.utils.getM(ev.target);
+                    const index = details.tag + '-' + details.id + '-' + details.src;
+                    if (f[index]) {
+                        return false;
                     }
-                    f[index] = false;
-                }, heartbeat * 1000);
-            }
-        }, {capture: true});
+                    f[index] = setTimeout(() => {
+                        if (ev.target.paused !== true && ev.target.ended !== true) {
+                            this.utils.transmit('playing', details.tag, user, context, {
+                                media: details,
+                            });
+                        }
+                        f[index] = false;
+                    }, heartbeat * 1000);
+                }
+            },
+            { capture: true },
+        );
     }
 
     trackForm(target) {
@@ -723,44 +846,63 @@ export default class AtlasTracking {
         }
         const targetEvents = ['focus', 'change'];
         let f = {
-            'name': target.name || target.id || '-',
-            'dataset': target.dataset,
-            'items_detail': {}
+            name: target.name || target.id || '-',
+            dataset: target.dataset,
+            items_detail: {},
         };
         for (let i = 0; i < targetEvents.length; i++) {
             this.eventHandler.remove(eventHandlerKeys['form'][targetEvents[i]]);
-            eventHandlerKeys['form'][targetEvents[i]] = this.eventHandler.add(target, targetEvents[i], (ev) => {
-                f = this.utils.getF(f, targetEvents[i], ev.target, pageLoadedAt);
-            }, false);
+            eventHandlerKeys['form'][targetEvents[i]] = this.eventHandler.add(
+                target,
+                targetEvents[i],
+                (ev) => {
+                    f = this.utils.getF(f, targetEvents[i], ev.target, pageLoadedAt);
+                },
+                false,
+            );
         }
         this.eventHandler.remove(eventHandlerKeys['formUnload']);
-        eventHandlerKeys['formUnload'] = this.eventHandler.add(targetWindow, unloadEvent, () => {
-            this.utils.transmit('track', 'form', user, context, {
-                'form': f
-            });
-        }, false);
+        eventHandlerKeys['formUnload'] = this.eventHandler.add(
+            targetWindow,
+            unloadEvent,
+            () => {
+                this.utils.transmit('track', 'form', user, context, {
+                    form: f,
+                });
+            },
+            false,
+        );
     }
 
     trackThroughMessage() {
         this.eventHandler.remove(eventHandlerKeys['message']);
-        eventHandlerKeys['message'] = this.eventHandler.add(targetWindow, 'message', (msg) => {
-            let attributes = {};
-            try{
-                attributes = JSON.parse(msg.data.attributes);
-            }catch(e){
-                // Nothing to do...
-            }
-            if(msg && msg.data && msg.data.isAtlasEvent){
-                const transmitContext = msg.data.contextOverride ? {...context, ...msg.data.contextOverride} : context;
-                const transmitUser = msg.data.userOverride ? {...user, ...msg.data.userOverride} : user;
-                this.utils.transmit(
-                    msg.data.action,
-                    msg.data.category,
-                    transmitUser,
-                    transmitContext,
-                    attributes
-                );
-            }
-        }, false);
+        eventHandlerKeys['message'] = this.eventHandler.add(
+            targetWindow,
+            'message',
+            (msg) => {
+                let attributes = {};
+                try {
+                    attributes = JSON.parse(msg.data.attributes);
+                } catch (e) {
+                    // Nothing to do...
+                }
+                if (msg && msg.data && msg.data.isAtlasEvent) {
+                    const transmitContext = msg.data.contextOverride
+                        ? { ...context, ...msg.data.contextOverride }
+                        : context;
+                    const transmitUser = msg.data.userOverride
+                        ? { ...user, ...msg.data.userOverride }
+                        : user;
+                    this.utils.transmit(
+                        msg.data.action,
+                        msg.data.category,
+                        transmitUser,
+                        transmitContext,
+                        attributes,
+                    );
+                }
+            },
+            false,
+        );
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,17 +36,14 @@ export default class Utils {
         if (self.crypto && self.crypto.getRandomValues) {
             const u32a = new Uint8Array(32);
             self.crypto.getRandomValues(u32a);
-            result = Array.from(
-                u32a,
-                (byte) => chars[byte % chars.length],
-            ).join("");
-        }else{
+            result = Array.from(u32a, (byte) => chars[byte % chars.length]).join('');
+        } else {
             // For IE compatibility
             for (let i = 0; i < 32; i++) {
                 result += chars[Math.floor(Math.random() * chars.length)];
             }
         }
-        this.uniqueId = `${timestamp}.${(result.substring(0,32))}`;
+        this.uniqueId = `${timestamp}.${result.substring(0, 32)}`;
         this.targetWindow = targetWindow;
     }
 
@@ -57,7 +54,14 @@ export default class Utils {
 
         atlasId = this.getC(atlasCookieName);
 
-        if (!atlasId || atlasId === '0' || atlasId === 0 || atlasId === '1' || atlasId === 1 || atlasId.length < 5) {
+        if (
+            !atlasId ||
+            atlasId === '0' ||
+            atlasId === 0 ||
+            atlasId === '1' ||
+            atlasId === 1 ||
+            atlasId.length < 5
+        ) {
             atlasId = this.getLS(atlasCookieName) || this.uniqueId;
         }
 
@@ -96,7 +100,7 @@ export default class Utils {
                 if (t.hasAttribute(d)) {
                     pt.unshift(t.getAttribute(d));
                 }
-            } 
+            }
 
             if (!e && matches(s)) {
                 if (t.tagName.toLowerCase() === 'a') {
@@ -111,29 +115,28 @@ export default class Utils {
         }
 
         return {
-            'element': e,
-            'category': c,
-            'pathTrackable': pt.join('>'),
-            'pathDom': pd.join('>')
+            element: e,
+            category: c,
+            pathTrackable: pt.join('>'),
+            pathDom: pd.join('>'),
         };
-
     }
 
     getAttr(attributeName, element) {
         let result = null;
-        if(attributeName){
+        if (attributeName) {
             result = element.getAttribute(attributeName);
         }
-        if(result === null) {
+        if (result === null) {
             result = undefined;
         }
-        
+
         return result;
     }
 
     getC(k) {
         const cookies = this.targetWindow.document.cookie.split(';');
-        for(let i = 0; i < cookies.length; i++) {
+        for (let i = 0; i < cookies.length; i++) {
             let cookie = cookies[i];
             while (cookie.charAt(0) === ' ') {
                 cookie = cookie.substring(1, cookie.length);
@@ -142,7 +145,7 @@ export default class Utils {
                 return cookie.substring(`${k}=`.length, cookie.length);
             }
         }
-        
+
         return '';
     }
 
@@ -159,7 +162,7 @@ export default class Utils {
                 return decodeURIComponent(pair[1]);
             }
         }
-        
+
         return '';
     }
 
@@ -184,13 +187,13 @@ export default class Utils {
 
     getNav() {
         let nav = {
-            history_length: this.targetWindow.history.length
+            history_length: this.targetWindow.history.length,
         };
         if ('performance' in this.targetWindow) {
             let p = this.targetWindow.performance;
             if ('getEntriesByType' in p) {
                 let navs = p.getEntriesByType('navigation');
-                if(navs.length >= 1) {
+                if (navs.length >= 1) {
                     nav.type = navs[0].type;
                     nav.redirectCount = navs[0].redirectCount;
                     nav.domContentLoaded = navs[0].domContentLoadedEventStart;
@@ -198,18 +201,20 @@ export default class Utils {
             }
             if ('getEntriesByName' in p) {
                 let paints = p.getEntriesByName('first-paint');
-                if(paints.length >= 1) {
+                if (paints.length >= 1) {
                     nav.first_paint = paints[0].startTime;
                 }
             }
         }
-        
+
         return nav;
     }
 
     getP() {
-        const tsDiff = function(tsStart, tsEnd){
-            return (tsEnd - tsStart < 0 || tsEnd - tsStart > 3600000) ? undefined :  Math.round(tsEnd - tsStart);
+        const tsDiff = function (tsStart, tsEnd) {
+            return tsEnd - tsStart < 0 || tsEnd - tsStart > 3600000
+                ? undefined
+                : Math.round(tsEnd - tsStart);
         };
         let p = {}; // Performance Timing
         let t = {}; // Navigation Type
@@ -217,24 +222,24 @@ export default class Utils {
         if ('performance' in this.targetWindow) {
             p = this.targetWindow.performance.timing;
             r = {
-                'unload': tsDiff(p.unloadEventStart, p.unloadEventEnd),
-                'redirect': tsDiff(p.redirectStart, p.redirectEnd),
-                'dns': tsDiff(p.domainLookupStart, p.domainLookupEnd),
-                'tcp': tsDiff(p.connectStart, p.connectEnd),
-                'request': tsDiff(p.requestStart, p.responseStart),
-                'response': tsDiff(p.responseStart, p.responseEnd),
-                'dom': tsDiff(p.domLoading, p.domContentLoadedEventStart),
-                'domContent': tsDiff(p.domContentLoadedEventStart, p.domContentLoadedEventEnd),
-                'onload': tsDiff(p.loadEventStart, p.loadEventEnd),
-                'untilResponseComplete': tsDiff(p.navigationStart, p.responseEnd),
-                'untilDomComplete': tsDiff(p.navigationStart, p.domContentLoadedEventStart)
+                unload: tsDiff(p.unloadEventStart, p.unloadEventEnd),
+                redirect: tsDiff(p.redirectStart, p.redirectEnd),
+                dns: tsDiff(p.domainLookupStart, p.domainLookupEnd),
+                tcp: tsDiff(p.connectStart, p.connectEnd),
+                request: tsDiff(p.requestStart, p.responseStart),
+                response: tsDiff(p.responseStart, p.responseEnd),
+                dom: tsDiff(p.domLoading, p.domContentLoadedEventStart),
+                domContent: tsDiff(p.domContentLoadedEventStart, p.domContentLoadedEventEnd),
+                onload: tsDiff(p.loadEventStart, p.loadEventEnd),
+                untilResponseComplete: tsDiff(p.navigationStart, p.responseEnd),
+                untilDomComplete: tsDiff(p.navigationStart, p.domContentLoadedEventStart),
             };
             t = (this.targetWindow.performance || {}).navigation;
         }
-        
+
         return {
-            'performanceResult': r,
-            'navigationType': t
+            performanceResult: r,
+            navigationType: t,
         };
     }
 
@@ -246,9 +251,9 @@ export default class Utils {
                     target: target,
                     type: type,
                     listener: listener,
-                    capture: capture
+                    capture: capture,
                 };
-                
+
                 return handlerKey++;
             },
             remove: function (handlerKey) {
@@ -256,7 +261,7 @@ export default class Utils {
                     let e = handlerEvents[handlerKey];
                     e.target.removeEventListener(e.type, e.listener, e.capture);
                 }
-            }
+            },
         };
     }
 
@@ -271,9 +276,14 @@ export default class Utils {
         const vph = this.targetWindow.innerHeight; //viewportHeight
         const dch = this.targetWindow.document.documentElement.scrollHeight; //documentHeight
         const div = this.targetWindow.document.visibilityState || 'unknown'; //documentIsVisible
-        const dvt = 'pageYOffset' in this.targetWindow ?
-            this.targetWindow.pageYOffset :
-            (this.targetWindow.document.documentElement || this.targetWindow.document.body.parentNode || this.targetWindow.document.body).scrollTop; //documentVisibleTop
+        const dvt =
+            'pageYOffset' in this.targetWindow
+                ? this.targetWindow.pageYOffset
+                : (
+                      this.targetWindow.document.documentElement ||
+                      this.targetWindow.document.body.parentNode ||
+                      this.targetWindow.document.body
+                  ).scrollTop; //documentVisibleTop
         const dvb = dvt + vph; //documentVisibleBottom
         const tgh = tgr.height; //targetHeight
         const tmt = tgr.top <= 0 ? 0 : tgr.top; //targetMarginTop
@@ -335,49 +345,49 @@ export default class Utils {
         tsr = tsu / tgh;
 
         return {
-            'detail': {
-                'viewportHeight': vph,
-                'documentHeight': dch,
-                'documentIsVisible': div,
-                'documentVisibleTop': dvt,
-                'documentVisibleBottom': dvb,
-                'targetHeight': tgh,
-                'targetVisibleTop': tvt,
-                'targetVisibleBottom': tvb,
-                'targetMarginTop': tmt,
-                'targetMarginBottom': tmb,
-                'targetScrollUntil': tsu,
-                'targetScrollRate': tsr,
-                'targetViewableRate': tvr,
-                'documentScrollUntil': dsu,
-                'documentScrollRate': dsr
+            detail: {
+                viewportHeight: vph,
+                documentHeight: dch,
+                documentIsVisible: div,
+                documentVisibleTop: dvt,
+                documentVisibleBottom: dvb,
+                targetHeight: tgh,
+                targetVisibleTop: tvt,
+                targetVisibleBottom: tvb,
+                targetMarginTop: tmt,
+                targetMarginBottom: tmb,
+                targetScrollUntil: tsu,
+                targetScrollRate: tsr,
+                targetViewableRate: tvr,
+                documentScrollUntil: dsu,
+                documentScrollRate: dsr,
             },
-            'status': {
-                'isInView': iiv,
-                'location': loc
-            }
+            status: {
+                isInView: iiv,
+                location: loc,
+            },
         };
     }
 
     getM(t) {
         if (t !== void 0) {
             return {
-                'tag': t.nodeName.toLowerCase() || 'na',
-                'id': t.id || 'na',
-                'src': t.src || 'na',
-                'type': t.type || undefined,
-                'codecs': t.codecs || undefined,
-                'muted': t.muted || false,
-                'default_muted': t.defaultMuted || false,
-                'autoplay': t.autoplay || false,
-                'width': t.clientWidth || undefined,
-                'height': t.clientHeight || undefined,
-                'player_id': t.playerId || undefined,
-                'played_percent': Math.round(t.currentTime / t.duration * 100),
-                'duration': t.duration,
-                'playback_rate': t.playbackRate || 1,
-                'current_time': Math.round(t.currentTime * 10) / 10,
-                'dataset': t.dataset
+                tag: t.nodeName.toLowerCase() || 'na',
+                id: t.id || 'na',
+                src: t.src || 'na',
+                type: t.type || undefined,
+                codecs: t.codecs || undefined,
+                muted: t.muted || false,
+                default_muted: t.defaultMuted || false,
+                autoplay: t.autoplay || false,
+                width: t.clientWidth || undefined,
+                height: t.clientHeight || undefined,
+                player_id: t.playerId || undefined,
+                played_percent: Math.round((t.currentTime / t.duration) * 100),
+                duration: t.duration,
+                playback_rate: t.playbackRate || 1,
+                current_time: Math.round(t.currentTime * 10) / 10,
+                dataset: t.dataset,
             };
         }
     }
@@ -393,7 +403,10 @@ export default class Utils {
                 }
             }
             l = a.length;
-        } else if (t.tagName.toLowerCase() === 'input' && (t.type === 'checkbox' || t.type === 'radio')) {
+        } else if (
+            t.tagName.toLowerCase() === 'input' &&
+            (t.type === 'checkbox' || t.type === 'radio')
+        ) {
             if (t.checked) {
                 l = 1;
             } else {
@@ -404,8 +417,8 @@ export default class Utils {
         }
         if (t.type !== 'hidden') {
             f.items_detail[n] = {
-                'status': e,
-                'length': l
+                status: e,
+                length: l,
             };
         }
         if (!f.first_item) {
@@ -415,22 +428,22 @@ export default class Utils {
         f.last_item = t.name || t.id || '-';
         f.last_item_since_page_load = (Date.now() - pl) / 1000;
         f.last_item_since_first_item = f.last_item_since_page_load - f.first_item_since_page_load;
-        
+
         return f;
     }
 
     getUniqueId() {
-        return  this.uniqueId;
+        return this.uniqueId;
     }
 
     buildIngest(u, c, s) {
         let igt = {
-            'user': u,
-            'context': {}
+            user: u,
+            context: {},
         }; //ingest
         let lyt = 'unknown'; //layout
         if (this.targetWindow.orientation) {
-            lyt = ((Math.abs(this.targetWindow.orientation) === 90) ? 'landscape' : 'portrait');
+            lyt = Math.abs(this.targetWindow.orientation) === 90 ? 'landscape' : 'portrait';
         }
 
         for (let i in c) {
@@ -440,14 +453,14 @@ export default class Utils {
             igt.context[i] = s[i];
         }
         const currentTime = new Date();
-        igt.user.timezone = currentTime.getTimezoneOffset() / 60 * -1;
+        igt.user.timezone = (currentTime.getTimezoneOffset() / 60) * -1;
         igt.user.timestamp = currentTime.toISOString();
         igt.user.viewport_height = this.targetWindow.innerHeight;
         igt.user.viewport_width = this.targetWindow.innerWidth;
         igt.user.screen_height = this.targetWindow.screen.height;
         igt.user.screen_width = this.targetWindow.screen.width;
         igt.user.layout = lyt;
-        
+
         return igt;
     }
 
@@ -460,7 +473,7 @@ export default class Utils {
         r = r.replace(/%22%3A/g, '%v');
         r = r.replace(/%2C%22/g, '%u');
         r = r.replace(/%7D%7D%7D/g, '%t');
-        
+
         return r;
     }
 
@@ -472,29 +485,33 @@ export default class Utils {
         }
         x.withCredentials = true;
 
-        try{
+        try {
             if (m === HTTP_METHOD_POST && b) {
-                x.setRequestHeader(HTTP_HEADER_CONTENT_TYPE, HTTP_HEADER_CONTENT_TYPE_APPLICATION_JSON);
+                x.setRequestHeader(
+                    HTTP_HEADER_CONTENT_TYPE,
+                    HTTP_HEADER_CONTENT_TYPE_APPLICATION_JSON,
+                );
                 x.send(new Blob([b], { type: HTTP_HEADER_CONTENT_TYPE_APPLICATION_JSON }));
             } else {
                 x.send();
             }
-        }catch(e){
+        } catch (e) {
             // Nothing to do...
         }
     }
 
     transmit(ac, ca, ur, ct, sp) {
         const now = Date.now();
-        const a = (!(ac === 'unload' && ca === 'page')); //async
+        const a = !(ac === 'unload' && ca === 'page'); //async
         let f = 1; //fpcStatus
         if (this.getC(atlasCookieName) !== atlasId) {
             f = 0;
         }
 
         const b = JSON.stringify(this.buildIngest(ur, ct, sp));
-        const _u = `https://${atlasEndpoint}/${sdkName}-${SDK_VERSION}/${now}/${encodeURIComponent(atlasId)}/${f}`
-            + `/ingest?k=${atlasApiKey}&a=${ac}&c=${ca}&aqe=%`; //endpointUrl
+        const _u =
+            `https://${atlasEndpoint}/${sdkName}-${SDK_VERSION}/${now}/${encodeURIComponent(atlasId)}/${f}` +
+            `/ingest?k=${atlasApiKey}&a=${ac}&c=${ca}&aqe=%`; //endpointUrl
 
         let u = _u + `&d=${this.compress(encodeURIComponent(b))}`;
         let m = HTTP_METHOD_GET;
@@ -520,31 +537,38 @@ export default class Utils {
             if (!sendBeaconStatus) {
                 this.xhr(u, a, m, b);
             }
-            
+
             return true;
         } else {
             const targetWindow = this.targetWindow;
-            if (('fetch' in targetWindow && typeof targetWindow.fetch === 'function')
-                && ('AbortController' in targetWindow && typeof targetWindow.AbortController === 'function')) {
+            if (
+                'fetch' in targetWindow &&
+                typeof targetWindow.fetch === 'function' &&
+                'AbortController' in targetWindow &&
+                typeof targetWindow.AbortController === 'function'
+            ) {
                 const controller = new targetWindow.AbortController();
                 const signal = controller.signal;
                 setTimeout(() => controller.abort(), atlasBeaconTimeout);
-                try{
+                try {
                     const options = { signal, method: m, cache: 'no-store', keepalive: true };
                     if (m === HTTP_METHOD_POST && b) {
-                        options['body'] = new Blob([b], { type: HTTP_HEADER_CONTENT_TYPE_APPLICATION_JSON });
+                        options['body'] = new Blob([b], {
+                            type: HTTP_HEADER_CONTENT_TYPE_APPLICATION_JSON,
+                        });
                         options['headers'] = {};
-                        options['headers'][HTTP_HEADER_CONTENT_TYPE] = HTTP_HEADER_CONTENT_TYPE_APPLICATION_JSON;
+                        options['headers'][HTTP_HEADER_CONTENT_TYPE] =
+                            HTTP_HEADER_CONTENT_TYPE_APPLICATION_JSON;
                     }
 
                     this.targetWindow.fetch(u, options);
-                }catch(e){
+                } catch (e) {
                     // Nothing to do...
                 }
             } else {
                 this.xhr(u, a, m, b);
             }
-            
+
             return true;
         }
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,16 +9,16 @@ describe('trackThroughMessage', () => {
             system: {
                 endpoint: 'example.test',
                 apiKey: 'dummy-api-key',
-                targetWindow: 'parent'
+                targetWindow: 'parent',
             },
             defaults: {},
             product: {},
             options: {
                 trackClick: {},
                 trackThroughMessage: {
-                    enable: true
-                }
-            }
+                    enable: true,
+                },
+            },
         });
 
         const pageUser = {
@@ -28,25 +28,27 @@ describe('trackThroughMessage', () => {
             url: 'https://example.test/base',
             page_title: 'base title',
             page_name: 'article',
-            page_num: 1
+            page_num: 1,
         };
 
         atlas.initPage({
             user: pageUser,
-            context: pageContext
+            context: pageContext,
         });
 
         const transmitSpy = vi.spyOn(atlas.utils, 'transmit').mockImplementation(() => {});
-        window.dispatchEvent(new MessageEvent('message', {
-            data: {
-                isAtlasEvent: true,
-                action: 'click',
-                category: 'button',
-                attributes: JSON.stringify({ cta: 'hero' }),
-                userOverride: { user_id: 'override-user' },
-                contextOverride: { url: 'https://example.test/override', page_num: 2 }
-            }
-        }));
+        window.dispatchEvent(
+            new MessageEvent('message', {
+                data: {
+                    isAtlasEvent: true,
+                    action: 'click',
+                    category: 'button',
+                    attributes: JSON.stringify({ cta: 'hero' }),
+                    userOverride: { user_id: 'override-user' },
+                    contextOverride: { url: 'https://example.test/override', page_num: 2 },
+                },
+            }),
+        );
 
         expect(transmitSpy).toHaveBeenCalledTimes(1);
         expect(transmitSpy).toHaveBeenCalledWith(
@@ -58,9 +60,9 @@ describe('trackThroughMessage', () => {
             expect.objectContaining({
                 url: 'https://example.test/override',
                 page_name: 'article',
-                page_num: 2
+                page_num: 2,
             }),
-            { cta: 'hero' }
+            { cta: 'hero' },
         );
         expect(pageUser.user_id).toBe('base-user');
         expect(pageContext.url).toBe('https://example.test/base');

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,81 +5,101 @@ describe('#transmit', () => {
     const utils = new Utils(globalThis);
     const sendBeaconMock = vi.spyOn(navigator, 'sendBeacon').mockImplementation(() => true);
     const xhrMock = vi.spyOn(utils, 'xhr').mockImplementation(() => {});
-    const fetchMock = vi.spyOn(utils.targetWindow, 'fetch').mockImplementation(() => Promise.resolve({}));
+    const fetchMock = vi
+        .spyOn(utils.targetWindow, 'fetch')
+        .mockImplementation(() => Promise.resolve({}));
 
     const byteSize = (s) => {
-      return s.replace(/%../g, '*').length
+        return s.replace(/%../g, '*').length;
     };
 
     beforeEach(() => {
         utils.initSystem({
-          endpoint: "example.com",
-          apiKey: "xxxxxxxxx",
-        })
+            endpoint: 'example.com',
+            apiKey: 'xxxxxxxxx',
+        });
 
         sendBeaconMock.mockClear();
         xhrMock.mockClear();
         fetchMock.mockClear();
 
         utils.setSendBeaconStatusForTestUse(true);
-    })
+    });
 
     it('should send ingest data by sendBeacon with HTTP POST with Body when request url size is greater than 8k', () => {
         // setup mock
         sendBeaconMock.mockReturnValue(true);
 
         // call HTTP request
-        utils.transmit('unload', 'page', {
-          "custom": "x".repeat(8 * (1 << 10))
-        }, {}, {});
+        utils.transmit(
+            'unload',
+            'page',
+            {
+                custom: 'x'.repeat(8 * (1 << 10)),
+            },
+            {},
+            {},
+        );
 
         // asserts
         expect(sendBeaconMock).toHaveBeenCalledTimes(1);
 
         const sendBeaconArgs = sendBeaconMock.mock.calls[0];
         expect(sendBeaconArgs[1]).toBeTruthy();
-        expect(sendBeaconArgs[1].size).toBeGreaterThan(8 * 1 << 10)
-        expect(sendBeaconArgs[1].type).toBe("application/json")
+        expect(sendBeaconArgs[1].size).toBeGreaterThan((8 * 1) << 10);
+        expect(sendBeaconArgs[1].type).toBe('application/json');
         expect(xhrMock).toHaveBeenCalledTimes(0);
-    })
+    });
 
     it('should send ingest data by xhr with HTTP POST with Body when request url size is greater than 8k', () => {
         // setup mock
         sendBeaconMock.mockReturnValue(false);
 
         // call HTTP request
-        utils.transmit('unload', 'page', {
-          "custom": "x".repeat(8 * (1 << 10))
-        }, {}, {});
+        utils.transmit(
+            'unload',
+            'page',
+            {
+                custom: 'x'.repeat(8 * (1 << 10)),
+            },
+            {},
+            {},
+        );
 
         // asserts
         expect(xhrMock).toHaveBeenCalledTimes(1);
 
-        const xhrMockArgs = xhrMock.mock.calls[0]
-        expect(xhrMockArgs[2]).toBe('POST')
-        expect(byteSize(xhrMockArgs[3])).toBeGreaterThan(8 * 1 << 10);
-    })
+        const xhrMockArgs = xhrMock.mock.calls[0];
+        expect(xhrMockArgs[2]).toBe('POST');
+        expect(byteSize(xhrMockArgs[3])).toBeGreaterThan((8 * 1) << 10);
+    });
 
     it('should send ingest data by fetch with HTTP POST with Body when request url size is greater than 8k', () => {
         // setup
         utils.setSendBeaconStatusForTestUse(false);
 
         // call HTTP request
-        utils.transmit('unload', 'page', {
-          "custom": "x".repeat(8 * (1 << 10))
-        }, {}, {});
+        utils.transmit(
+            'unload',
+            'page',
+            {
+                custom: 'x'.repeat(8 * (1 << 10)),
+            },
+            {},
+            {},
+        );
 
         // asserts
         expect(fetchMock).toHaveBeenCalledTimes(1);
-        const fetchMockArgs = fetchMock.mock.calls[0]
+        const fetchMockArgs = fetchMock.mock.calls[0];
 
-        expect(fetchMockArgs[1]['method']).toBe('POST')
-        expect(fetchMockArgs[1]['body'].size).toBeGreaterThan(8 * 1 << 10);
+        expect(fetchMockArgs[1]['method']).toBe('POST');
+        expect(fetchMockArgs[1]['body'].size).toBeGreaterThan((8 * 1) << 10);
         expect(fetchMockArgs[1]['body'].type).toBe('application/json');
         expect(fetchMockArgs[1]['headers']['Content-Type']).toBe('application/json');
         expect(sendBeaconMock).toHaveBeenCalledTimes(0);
         expect(xhrMock).toHaveBeenCalledTimes(0);
-    })
+    });
 
     it('should send ingest data by xhr with HTTP POST with Body when request url size is greater than 8k and fetch function is not implemented.', () => {
         // setup mock
@@ -89,22 +109,27 @@ describe('#transmit', () => {
         delete utils.targetWindow.fetch;
 
         // call HTTP request
-        utils.transmit('unload', 'page', {
-          "custom": "x".repeat(8 * (1 << 10))
-        }, {}, {});
+        utils.transmit(
+            'unload',
+            'page',
+            {
+                custom: 'x'.repeat(8 * (1 << 10)),
+            },
+            {},
+            {},
+        );
 
         // asserts
         expect(fetchMock).toHaveBeenCalledTimes(0);
         expect(sendBeaconMock).toHaveBeenCalledTimes(0);
 
-        const xhrMockArgs = xhrMock.mock.calls[0]
-        expect(xhrMockArgs[2]).toBe('POST')
-        expect(byteSize(xhrMockArgs[3])).toBeGreaterThan(8 * 1 << 10);
+        const xhrMockArgs = xhrMock.mock.calls[0];
+        expect(xhrMockArgs[2]).toBe('POST');
+        expect(byteSize(xhrMockArgs[3])).toBeGreaterThan((8 * 1) << 10);
 
         // cleanup
         utils.targetWindow.fetch = originalFetch;
-    })
-
+    });
 
     it('should send ingest data by sendBeacon with HTTP GET when request url size is less than 8k', () => {
         // setup mock
@@ -116,9 +141,9 @@ describe('#transmit', () => {
         // asserts
         expect(sendBeaconMock).toHaveBeenCalledTimes(1);
         expect(sendBeaconMock.mock.calls[0][1]).toBeNull();
-        expect(byteSize(sendBeaconMock.mock.calls[0][0])).toBeLessThan(8 * 1 << 10);
+        expect(byteSize(sendBeaconMock.mock.calls[0][0])).toBeLessThan((8 * 1) << 10);
         expect(xhrMock).toHaveBeenCalledTimes(0);
-    })
+    });
 
     it('should send ingest data by fetch with HTTP GET when request url size is less than 8k', () => {
         // setup
@@ -129,11 +154,11 @@ describe('#transmit', () => {
 
         // asserts
         expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock.mock.calls[0][1]['method']).toBe('GET')
-        expect(byteSize(fetchMock.mock.calls[0][0])).toBeLessThan(8 * 1 << 10);
+        expect(fetchMock.mock.calls[0][1]['method']).toBe('GET');
+        expect(byteSize(fetchMock.mock.calls[0][0])).toBeLessThan((8 * 1) << 10);
         expect(sendBeaconMock).toHaveBeenCalledTimes(0);
         expect(xhrMock).toHaveBeenCalledTimes(0);
-    })
+    });
 
     it('should send ingest data by xhr with HTTP GET when request url size is less than 8k and fetch function is not implemented.', () => {
         // setup mock
@@ -150,12 +175,12 @@ describe('#transmit', () => {
         expect(fetchMock).toHaveBeenCalledTimes(0);
         expect(sendBeaconMock).toHaveBeenCalledTimes(0);
         expect(xhrMock).toHaveBeenCalledTimes(1);
-        expect(byteSize(xhrMock.mock.calls[0][0])).toBeLessThan(8 * 1 << 10);
-        expect(xhrMock.mock.calls[0][2]).toBe('GET')
+        expect(byteSize(xhrMock.mock.calls[0][0])).toBeLessThan((8 * 1) << 10);
+        expect(xhrMock.mock.calls[0][2]).toBe('GET');
 
         // cleanup
         utils.targetWindow.fetch = originalFetch;
-    })
+    });
 
     it('should send ingest data by xhr with HTTP GET when request url size is less than 8k', () => {
         // setup mock
@@ -166,8 +191,8 @@ describe('#transmit', () => {
 
         // asserts
         expect(xhrMock).toHaveBeenCalledTimes(1);
-        expect(xhrMock.mock.calls[0][2]).toBe('GET')
-        expect(byteSize(xhrMock.mock.calls[0][0])).toBeLessThan(8 * 1 << 10);
+        expect(xhrMock.mock.calls[0][2]).toBe('GET');
+        expect(byteSize(xhrMock.mock.calls[0][0])).toBeLessThan((8 * 1) << 10);
     });
 });
 
@@ -198,7 +223,9 @@ describe('#initSystem', () => {
         const storeId = 'aabbcc.testlocalstorageatlasId';
         localStorage.setItem('atlasId', storeId);
         const cookieId = 'aabbcc.testcookieatlasId';
-        vi.spyOn(globalThis.document, 'cookie', 'get').mockReturnValue(`atlasId=${cookieId}; path=/;`); 
+        vi.spyOn(globalThis.document, 'cookie', 'get').mockReturnValue(
+            `atlasId=${cookieId}; path=/;`,
+        );
 
         const utils = new Utils(globalThis);
         utils.initSystem(systemConfig);


### PR DESCRIPTION
## Summary

- Introduce [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) as the project formatter
- Remove formatting rules from ESLint that are now delegated to oxfmt
- Apply oxfmt to all source and test files

## What changed

**Formatter setup**
- Added `oxfmt` as a dev dependency
- Added `.oxfmtrc.json` with `tabWidth: 4` and `singleQuote: true` to match the existing code style
- Added `format` and `format:check` scripts covering `src/` and `test/`

**ESLint cleanup**
- Removed `indent` and `newline-before-return` rules from `eslint.config.mjs`

**Code formatting**
- Mechanical, no-logic-change formatting pass across all JS files