### PR TITLE
fix: remove timeupdate listener when disabling media tracking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -339,7 +339,7 @@ export default class AtlasTracking {
             this.eventHandler.remove(eventHandlerKeys['viewability']);
         }
         if (options.trackMedia && options.trackMedia.enable) {
-            const targetEvents = ['play', 'pause', 'ended'];
+            const targetEvents = ['play', 'pause', 'ended', 'timeupdate'];
             for (let i = 0; i < targetEvents.length; i++) {
                 this.eventHandler.remove(eventHandlerKeys['media'][targetEvents[i]]);
             }


### PR DESCRIPTION
`disableTracking()` removes the `play` / `pause` / `ended` listeners, but not the `timeupdate` listener for playing tracking
Hence added `timeupdate` to the list of events cleaned up in `disableTracking()`, matching what `trackMedia()` registers